### PR TITLE
Type & Expression Updates

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/Terminals.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/Terminals.scala
@@ -30,6 +30,7 @@ object Terminals {
     final val equals = "="
     final val ellipsis = "..."
     final val ellipsisQuestion = "...?"
+    final val exclamation = "!"
     final val plus = "+"
     final val question = "?"
     final val quote = "\""

--- a/language/src/main/scala/com/reactific/riddl/language/Validation.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/Validation.scala
@@ -361,12 +361,15 @@ object Validation {
         case Enumeration(_, enumerators) =>
           checkEnumeration(definition, enumerators)
         case alt: Alternation => checkAlternation(definition, alt)
-        case agg: Aggregation => checkAggregation(definition, agg)
-        case mt: MessageType  => checkMessageType(definition, mt)
         case mapping: Mapping => checkMapping(definition, mapping)
         case rt: RangeType    => checkRangeType(definition, rt)
         case ReferenceType(_, entity: EntityRef) => this
             .checkRef[Entity](entity)
+        case ate: AggregateTypeExpression =>
+          ate match {
+            case agg: Aggregation => checkAggregation(definition, agg)
+            case mt: MessageType => checkMessageType(definition, mt)
+          }
       }
     }
 
@@ -783,7 +786,7 @@ object Validation {
 
     def checkExpression(expression: Expression): ValidationState = {
       expression match {
-        case ValueCondition(_, path)  => checkPathRef[Field](path)()
+        case ValueExpression(_, path)  => checkPathRef[Field](path)()
         case GroupExpression(_, expr) => checkExpression(expr)
         case FunctionCallExpression(loc, pathId, arguments) =>
           checkFunctionCall(loc, pathId, arguments)

--- a/testkit/src/test/scala/com/reactific/riddl/language/ConditionParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ConditionParserTest.scala
@@ -42,7 +42,7 @@ class ConditionParserTest extends ParsingTest {
     "accept literal string" in {
       parseCondition("\"decide\"") { cond: Condition =>
         cond mustBe
-          ArbitraryCondition(LiteralString(Location(1 -> 1), "decide"))
+          ArbitraryExpression(LiteralString(Location(1 -> 1), "decide"))
       }
     }
     "accept and(true,false)" in {
@@ -94,13 +94,13 @@ class ConditionParserTest extends ParsingTest {
             Comparison(
               1 -> 4,
               lt,
-              ValueCondition(1 -> 6, PathIdentifier(1 -> 7, Seq("a"))),
+              ValueExpression(1 -> 6, PathIdentifier(1 -> 7, Seq("a"))),
               LiteralInteger(1 -> 9, BigInt(42))
             ),
             Comparison(
               1 -> 13,
               lt,
-              ValueCondition(1 -> 15, PathIdentifier(1 -> 16, Seq("b"))),
+              ValueExpression(1 -> 15, PathIdentifier(1 -> 16, Seq("b"))),
               FunctionCallExpression(
                 1 -> 18,
                 PathIdentifier(1 -> 18, Seq("SomeFunc")),
@@ -126,7 +126,7 @@ class ConditionParserTest extends ParsingTest {
                   Comparison(
                     1 -> 12,
                     AST.eq,
-                    ArbitraryCondition(LiteralString(1 -> 15, "sooth")),
+                    ArbitraryExpression(LiteralString(1 -> 15, "sooth")),
                     False(1 -> 24)
                   )
                 ),

--- a/testkit/src/test/scala/com/reactific/riddl/language/ExpressionParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ExpressionParserTest.scala
@@ -155,8 +155,8 @@ class ExpressionParserTest extends ParsingTest {
           Comparison(
             1 -> 4,
             lt,
-            ValueCondition(1 -> 6, PathIdentifier(1 -> 7, Seq("a"))),
-            ValueCondition(1 -> 9, PathIdentifier(1 -> 10, Seq("b")))
+            ValueExpression(1 -> 6, PathIdentifier(1 -> 7, Seq("a"))),
+            ValueExpression(1 -> 9, PathIdentifier(1 -> 10, Seq("b")))
           ),
           LiteralInteger(1 -> 13, BigInt(42)),
           LiteralInteger(1 -> 16, BigInt(21))

--- a/testkit/src/test/scala/com/reactific/riddl/language/ParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ParserTest.scala
@@ -211,7 +211,7 @@ class ParserTest extends ParsingTest {
         case Right((content, rpi)) => content mustBe Invariant(
             (1, 11, rpi),
             Identifier((1, 11, rpi), "large"),
-            ArbitraryCondition(
+            ArbitraryExpression(
               LiteralString((1, 22, rpi), "x is greater or equal to 10")
             ),
             None
@@ -275,7 +275,7 @@ class ParserTest extends ParsingTest {
                 ),
                 Seq(WhenClause(
                   (9, 7, rpi),
-                  ArbitraryCondition(
+                  ArbitraryExpression(
                     LiteralString((9, 12, rpi), "I go fishing")
                   )
                 )),

--- a/testkit/src/test/scala/com/reactific/riddl/language/TypeParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/TypeParserTest.scala
@@ -1,6 +1,6 @@
 package com.reactific.riddl.language
 
-import com.reactific.riddl.language.AST.*
+import com.reactific.riddl.language.AST.{Field, *}
 import com.reactific.riddl.language.parsing.RiddlParserInput
 import com.reactific.riddl.language.testkit.ParsingTest
 
@@ -271,6 +271,21 @@ class TypeParserTest extends ParsingTest {
         Optional(
           (1, 26, rip),
           TypeRef((1, 26, rip), PathIdentifier((1, 26, rip), Seq("agg")))
+        )
+      )
+      checkDefinition[Type, Type](rip, expected, identity)
+    }
+    "allow messages defined with more natural syntax" in {
+      val rip = RiddlParserInput("command foo is { a: Integer }")
+      val expected = Type((1,1,rip), Identifier((1, 9, rip), "foo"),
+        MessageType((1,16,rip),CommandKind,
+          Seq(
+            Field((1,16,rip),Identifier((1,16,rip),"sender"),
+              ReferenceType((1,16,rip),EntityRef((1,16,rip),
+                PathIdentifier((1,16,rip),List())))
+            ),
+            Field((1,18,rip),Identifier((1,18,rip),"a"), Integer((1,21,rip)))
+          )
         )
       )
       checkDefinition[Type, Type](rip, expected, identity)


### PR DESCRIPTION
- New syntax for defining message types with just
   the message kind keyword
- Test case to test new syntax: "command foo is { a: Integer }"
- Correct naming of conditions that are expressions
- Reorganize ExpressionParser for comprehension
- Add AggregateConstructionExpression and its parser to support
  creating Aggregates and Messages in expressions