### PR TITLE
Allow PlantDefinitions in Contexts

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/AST.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/AST.scala
@@ -2233,6 +2233,7 @@ object AST {
     entities: Seq[Entity] = Seq.empty[Entity],
     adaptors: Seq[Adaptor] = Seq.empty[Adaptor],
     sagas: Seq[Saga] = Seq.empty[Saga],
+    processors: Seq[Processor] = Seq.empty[Processor],
     functions: Seq[Function] = Seq.empty[Function],
     terms: Seq[Term] = Seq.empty[Term],
     includes: Seq[Include] = Seq.empty[Include],
@@ -2270,7 +2271,7 @@ object AST {
     transmitType: Option[TypeRef],
     brief: Option[LiteralString] = None,
     description: Option[Description] = None)
-      extends PlantDefinition
+      extends PlantDefinition with ContextDefinition
 
   /** Base trait of definitions defined in a processor
     */
@@ -2381,7 +2382,8 @@ object AST {
     examples: Seq[Example],
     brief: Option[LiteralString] = Option.empty[LiteralString],
     description: Option[Description] = None)
-      extends ParentDefOf[ProcessorDefinition] with PlantDefinition {
+      extends ParentDefOf[ProcessorDefinition] with PlantDefinition
+      with ContextDefinition {
     override def contents: Seq[ProcessorDefinition] = inlets ++ outlets ++
       examples
   }
@@ -2431,7 +2433,7 @@ object AST {
 
   /** Sealed base trait for both kinds of Joint definitions
     */
-  sealed trait Joint extends PlantDefinition
+  sealed trait Joint extends PlantDefinition with ContextDefinition
 
   /** A joint that connects an [[Processor]]'s [[Inlet]] to a [[Pipe]].
     *

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ContextParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ContextParser.scala
@@ -27,6 +27,7 @@ trait ContextParser
     with AdaptorParser
     with EntityParser
     with SagaParser
+    with StreamingParser
     with TypeParser {
 
   def contextOptions[X: P]: P[Seq[ContextOption]] = {
@@ -48,8 +49,8 @@ trait ContextParser
   def contextDefinitions[u: P]: P[Seq[ContextDefinition]] = {
     P(
       undefined(Seq.empty[ContextDefinition]) |
-        (typeDef | contextHandler | entity | adaptor | function | saga | term |
-          contextInclude).rep(0)
+        (typeDef | contextHandler | entity | adaptor | function | saga |
+          plantDefinition | term | contextInclude).rep(0)
     )
   }
 
@@ -65,6 +66,7 @@ trait ContextParser
       val functions = mapTo[Function](groups.get(classOf[Function]))
       val entities = mapTo[Entity](groups.get(classOf[Entity]))
       val adaptors = mapTo[Adaptor](groups.get(classOf[Adaptor]))
+      val processors = mapTo[Processor](groups.get(classOf[Processor]))
       val terms = mapTo[Term](groups.get(classOf[Term]))
       val includes = mapTo[Include](groups.get(classOf[Include]))
       val sagas = mapTo[Saga](groups.get(classOf[Saga]))
@@ -76,6 +78,7 @@ trait ContextParser
         entities,
         adaptors,
         sagas,
+        processors,
         functions,
         terms,
         includes,


### PR DESCRIPTION
- All PlantDefinitions also became ContextDefinitions
- Refactored StreamingParser to allow ContextParser
  to use plantDefinition (singular)
- Added a test case for a Source in a Context
- Fixed inlet and outlet optional entity integration direction