### PR TITLE
Hugo improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Build Status](https://github.com/reactific/riddl/actions/workflows/scala.yml/badge.svg)
-![Build Status](https://github.com/reactific/riddl/actions/workflows/gh-pages.yml/badge.svg)
+![Code Build Status](https://github.com/reactific/riddl/actions/workflows/scala.yml/badge.svg)
+![Documentation Build Status](https://github.com/reactific/riddl/actions/workflows/gh-pages.yml/badge.svg)
 
 # RIDDL
 
@@ -21,8 +21,9 @@ of the domain abstractions.
 To use `riddlc` locally and be able to update it with new changes, use this 
 approach:
 * `git clone` the latest content and change directory to that cloned repository
-* Put the `.../riddl/riddlc/target/stage/bin` directory in your PATH variable
-* Run `sbt "stage"` to build the program
+* Put the `.../riddl/riddlc/target/universal/stage/bin` directory in your PATH 
+  variable
+* Run `sbt stage` to build the program
 * To update, run `git pull` from the `riddl` cloned repository directory and
   rerun the sbt command above to rebuild. 
 
@@ -48,6 +49,12 @@ After downloading the `.zip` asset, you should:
 ## Adding `riddlc` to your project workflow
 * See the reactific/riddl-actions project for actions that make riddlc invokable 
   in your own GitHub workflows
+
+## Using RIDDL From Code
+In your `project/plugins.sbt` file, use:
+```shell
+addSbtPlugin("com.reactific" % "sbt-riddl" % "<version>")
+```
 
 ## Usage
 To get the most recent options, run `riddlc --help`. That command will give you

--- a/hugo-translator/src/main/scala/com/reactific/riddl/translator/hugo/HugoTranslator.scala
+++ b/hugo-translator/src/main/scala/com/reactific/riddl/translator/hugo/HugoTranslator.scala
@@ -432,8 +432,6 @@ object HugoTranslator extends Translator[HugoTranslatingOptions] {
        |title = "$siteTitle"
        |name = "$siteName"
        |description = "$siteDescription"
-       |homepage = "https://example.org/"
-       |demosite = "https://example.org/"
        |tags = ["docs", "documentation", "responsive", "simple", "riddl"]
        |min_version = "0.83.0"
        |theme = $themes

--- a/hugo-translator/src/main/scala/com/reactific/riddl/translator/hugo/HugoTranslator.scala
+++ b/hugo-translator/src/main/scala/com/reactific/riddl/translator/hugo/HugoTranslator.scala
@@ -31,17 +31,18 @@ case class HugoTranslatingOptions(
   outputDir: Option[Path] = None,
   eraseOutput: Boolean = false,
   projectName: Option[String] = None,
+  siteTitle: Option[String] = None,
+  siteDescription: Option[String] = None,
+  siteLogoPath: Option[String] = Some("images/logo.png"),
   baseUrl: Option[URL] = Option(new URL("https://example.com/")),
   themes: Seq[(String, Option[URL])] =
     Seq("hugo-geekdoc" -> Option(HugoTranslator.geekDoc_url)),
   sourceURL: Option[URL] = Some(new URL("http://localhost:1313/")),
   editPath: Option[String] = None,
-  siteLogo: Option[URL] = None,
-  siteLogoPath: Option[String] = Some("images/logo.png"),
   withGlossary: Boolean = true,
   withTODOList: Boolean = true,
-  withGraphicalTOC: Boolean = false)
-    extends TranslatingOptions {
+  withGraphicalTOC: Boolean = false
+) extends TranslatingOptions {
   def outputRoot: Path = outputDir.getOrElse(Path.of("")).toAbsolutePath
   def contentRoot: Path = outputRoot.resolve("content")
   def staticRoot: Path = outputRoot.resolve("static")
@@ -155,14 +156,11 @@ case class HugoTranslatorState(options: HugoTranslatingOptions) {
 
 object HugoTranslator extends Translator[HugoTranslatingOptions] {
 
-  val geekdoc_dest_dir = "hugo-geekdoc"
   val geekDoc_version = "v0.34.1"
   val geekDoc_file = "hugo-geekdoc.tar.gz"
   val geekDoc_url = new URL(
     s"https://github.com/thegeeklab/hugo-geekdoc/releases/download/$geekDoc_version/$geekDoc_file"
   )
-
-  val sitemap_xsd = "https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
 
   def deleteAll(directory: File): Boolean = {
     val maybeFiles = Option(directory.listFiles)
@@ -246,16 +244,6 @@ object HugoTranslator extends Translator[HugoTranslatingOptions] {
     }
   }
 
-  def loadSiteLogo(options: HugoTranslatingOptions): Path = {
-    options.siteLogo match {
-      case Some(url) =>
-        val fileName = PathUtils.copyURLToDir(url, options.staticRoot)
-        options.staticRoot.resolve(fileName)
-      case None =>
-        options.staticRoot.resolve("logo.png")
-    }
-  }
-
   def copyResource(destination: Path):Unit = {
     import java.nio.file.Files
     import java.nio.file.StandardCopyOption
@@ -265,39 +253,34 @@ object HugoTranslator extends Translator[HugoTranslatingOptions] {
     Files.copy(src, destination, StandardCopyOption.REPLACE_EXISTING)
   }
 
-  def manuallyMakeNewHugoSite(where: File): Unit = {
-    val path = where.toPath
-    if (Files.isDirectory(path)) {
-      Files.createDirectories(path.resolve("archetypes"))
-      Files.createDirectories(path.resolve("content"))
-      Files.createDirectories(path.resolve("data"))
-      Files.createDirectories(path.resolve("layouts"))
-      Files.createDirectories(path.resolve("public"))
-      Files.createDirectories(path.resolve("static"))
-      Files.createDirectories(path.resolve("themes"))
-      copyResource(path.resolve("config.toml"))
-      copyResource(path.resolve("archetypes").resolve("default.md"))
-    }
+  def manuallyMakeNewHugoSite(path: Path): Unit = {
+    Files.createDirectories(path)
+    Files.createDirectories(path.resolve("archetypes"))
+    Files.createDirectories(path.resolve("content"))
+    Files.createDirectories(path.resolve("data"))
+    Files.createDirectories(path.resolve("layouts"))
+    Files.createDirectories(path.resolve("public"))
+    Files.createDirectories(path.resolve("static"))
+    Files.createDirectories(path.resolve("themes"))
+    copyResource(path.resolve("archetypes").resolve("default.md"))
   }
 
   def makeDirectoryStructure(
     inputPath: Path,
     log: Logger,
     options: HugoTranslatingOptions
-  ): HugoTranslatingOptions = {
+  ): Unit = {
     val outDir = options.outputRoot.toFile
-    if (outDir.exists()) { if (options.eraseOutput) { deleteAll(outDir) } }
-    else { outDir.mkdirs() }
+    if (outDir.exists()) {if (options.eraseOutput) {deleteAll(outDir)}}
+    else {outDir.mkdirs()}
     val parent = outDir.getParentFile
     require(
       parent.isDirectory,
       "Parent of output directory is not a directory!"
     )
-    manuallyMakeNewHugoSite(outDir)
+    manuallyMakeNewHugoSite(outDir.toPath)
     loadThemes(options)
     loadStaticAssets(inputPath, log, options)
-    val logoPath = loadSiteLogo(options).relativize(options.staticRoot).toString
-    options.copy(siteLogoPath = Option(logoPath))
   }
 
   def writeConfigToml(
@@ -352,12 +335,12 @@ object HugoTranslator extends Translator[HugoTranslatingOptions] {
       options.outputRoot.getFileName.toString.nonEmpty,
       "Output path is empty"
     )
-    val newOptions = makeDirectoryStructure(options.inputFile.get, log, options)
-    val maybeAuthor = root.contents.headOption match {
-      case Some(domain) => domain.author
-      case None         => Option.empty[AuthorInfo]
+    makeDirectoryStructure(options.inputFile.get, log, options)
+    val someAuthors = root.contents.headOption match {
+      case Some(domain) => domain.authors
+      case None         => Seq.empty[AuthorInfo]
     }
-    writeConfigToml(newOptions, maybeAuthor)
+    writeConfigToml(options, someAuthors.headOption)
     val state = HugoTranslatorState(options)
     val parentStack = mutable.Stack[ParentDefOf[Definition]]()
 
@@ -424,27 +407,31 @@ object HugoTranslator extends Translator[HugoTranslatingOptions] {
   ): String = {
     val auth: AuthorInfo = author.getOrElse(AuthorInfo(
       1 -> 1,
+      id = Identifier(1->1,"unknown"),
       name = LiteralString(1 -> 1, "Not Provided"),
       email = LiteralString(1 -> 1, "somebody@somewere.tld")
     ))
     val themes: String = {
       options.themes.map(_._1).mkString("[ \"", "\", \"", "\" ]")
     }
+    val baseURL: String = options.baseUrl.fold("https://example.prg/")(_.toString)
     val srcURL: String = options.sourceURL.fold("")(_.toString)
     val editPath: String = options.editPath.getOrElse("")
-    val siteLogoPath: String = options.siteLogoPath.getOrElse("logo.png")
+    val siteLogoPath: String = options.siteLogoPath.getOrElse("images/logo.png")
     val legalPath: String = "/legal"
     val privacyPath: String = "/privacy"
+    val siteTitle = options.siteTitle.getOrElse("Unspecified Site Title")
+    val siteName = options.projectName.getOrElse("Unspecified Project Name")
+    val siteDescription = options.siteDescription.getOrElse("Unspecified Project Description")
 
     s"""######################## Hugo Configuration ####################
        |
        |# Configure GeekDocs
-       |languageCode = 'en-us'
-       |title = '${options.projectName.getOrElse("Unspecified Project Title")}'
-       |name = "${options.projectName.getOrElse("Unspecified Project Name")}"
-       |description = "${options.projectName
-      .getOrElse("Unspecified Project Description")}"
-       |baseUrl = "${options.baseUrl.fold("https://example.prg/")(_.toString)}"
+       |baseUrl = "$baseURL"
+       |languageCode = "en-us"
+       |title = "$siteTitle"
+       |name = "$siteName"
+       |description = "$siteDescription"
        |homepage = "https://example.org/"
        |demosite = "https://example.org/"
        |tags = ["docs", "documentation", "responsive", "simple", "riddl"]

--- a/hugo-translator/src/main/scala/com/reactific/riddl/translator/hugo/MarkdownWriter.scala
+++ b/hugo-translator/src/main/scala/com/reactific/riddl/translator/hugo/MarkdownWriter.scala
@@ -263,8 +263,7 @@ case class MarkdownWriter(filePath: Path) {
   def emitDomain(domain: Domain, parents: Seq[String]): this.type = {
     fileHead(domain)
     title(domain)
-    if (domain.author.nonEmpty) {
-      val a = domain.author.get
+    for (a <- domain.authors) {
       val items = Seq("Name" -> a.name.s, "Email" -> a.email.s) ++
         a.organization.fold(Seq.empty[(String, String)])(ls =>
           Seq("Organization" -> ls.s)

--- a/language/src/main/scala/com/reactific/riddl/language/AST.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/AST.scala
@@ -2688,13 +2688,15 @@ object AST {
     */
   case class AuthorInfo(
     loc: Location,
+    id: Identifier,
     name: LiteralString,
     email: LiteralString,
     organization: Option[LiteralString] = None,
     title: Option[LiteralString] = None,
     url: Option[java.net.URL] = None,
+    brief: Option[LiteralString] = None,
     description: Option[Description] = None)
-      extends DescribedValue {
+      extends DomainDefinition {
     override def isEmpty: Boolean = {
       name.isEmpty && email.isEmpty && organization.isEmpty && title.isEmpty
     }
@@ -2728,7 +2730,7 @@ object AST {
   case class Domain(
     loc: Location,
     id: Identifier,
-    author: Option[AuthorInfo] = Option.empty[AuthorInfo],
+    authors: Seq[AuthorInfo] = Seq.empty[AuthorInfo],
     types: Seq[Type] = Seq.empty[Type],
     contexts: Seq[Context] = Seq.empty[Context],
     plants: Seq[Plant] = Seq.empty[Plant],
@@ -2742,10 +2744,9 @@ object AST {
       with DomainDefinition
       with WithIncludes
       with WithTerms {
-    override def isEmpty: Boolean = super.isEmpty && author.isEmpty
     def contents: Seq[DomainDefinition] = {
       domains ++ types.iterator ++ contexts ++ plants ++ stories ++ terms ++
-        includes
+        includes ++ authors
     }
   }
 }

--- a/language/src/main/scala/com/reactific/riddl/language/ReformatTranslator.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ReformatTranslator.scala
@@ -531,26 +531,23 @@ object ReformatTranslator extends Translator[ReformattingOptions] {
       state: ReformatState,
       domain: Domain
     ): ReformatState = {
-      state.withCurrent(_.openDef(domain)).step { s1 =>
-        if (domain.author.nonEmpty && domain.author.get.nonEmpty) {
-          val author = domain.author.get
-          s1.withCurrent(_.addIndent(s"author is {\n")
+      state.withCurrent(_.openDef(domain)).step { s1: ReformatState =>
+        domain.authors.foldLeft(s1) { (st, author) =>
+          st.withCurrent(_.addIndent(s"author is {\n")
             .indent
             .addIndent(s"name = ${author.name.format}\n")
             .addIndent(s"email = ${author.email.format}\n")
           ).step { s2 =>
-              author.organization
-                .map(org => s2.withCurrent(
-                  _.addIndent(s"organization =${org.format}\n")))
-                .orElse(Option(s2)).get
-            }.step { s3 =>
-              author.title
-                .map(title => s3.withCurrent(
-                  _.addIndent(s"title = ${title.format}\n")))
-                .orElse(Option(s3)).get
-            }.withCurrent(_.outdent.addIndent("}\n"))
-        } else {
-          s1
+            author.organization
+              .map(org => s2.withCurrent(
+                _.addIndent(s"organization =${org.format}\n")))
+              .orElse(Option(s2)).get
+          }.step { s3 =>
+            author.title
+              .map(title => s3.withCurrent(
+                _.addIndent(s"title = ${title.format}\n")))
+              .orElse(Option(s3)).get
+          }.withCurrent(_.outdent.addIndent("}\n"))
         }
       }
     }

--- a/riddlc/src/test/scala/com/reactific/riddl/RiddlOptionsTest.scala
+++ b/riddlc/src/test/scala/com/reactific/riddl/RiddlOptionsTest.scala
@@ -3,7 +3,6 @@ package com.reactific.riddl
 import com.reactific.riddl.RiddlOptions.Hugo
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-
 import java.nio.file.Path
 
 class RiddlOptionsTest extends AnyWordSpec with Matchers {
@@ -74,7 +73,6 @@ class RiddlOptionsTest extends AnyWordSpec with Matchers {
           ho.sourceURL mustBe Option(
             new java.net.URL("https://github.com/reactific/riddl"))
           ho.editPath mustBe Option("/-/blob/main/examples/src/riddl/ReactiveBBQ")
-          ho.siteLogo mustBe None
           ho.siteLogoPath mustBe Option("/images/RBBQ.png")
       }
     }

--- a/testkit/src/test/scala/com/reactific/riddl/language/DomainValidatorTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/DomainValidatorTest.scala
@@ -35,21 +35,24 @@ class DomainValidatorTest extends ValidatingTest {
                     |    email: "reid@reactific.com"
                     |    organization: "Reactific Software Inc."
                     |    title: "President"
-                    |  }
+                    |  } described as "identifying"
                     |} described as "example"
                     |""".stripMargin
       parseAndValidate[Domain](input) {
         (domain: Domain, rpi: RiddlParserInput, messages: ValidationMessages) =>
           domain mustNot be(empty)
-          domain.contents mustBe empty
+          domain.contents mustNot be(empty)
           val expectedAuthor = AuthorInfo(
             (2, 3, rpi), Identifier((2,10,rpi), "Reid"),
             LiteralString((3, 11, rpi), "Reid Spencer"),
             LiteralString((4, 12, rpi), "reid@reactific.com"),
             Some(LiteralString((5, 19, rpi), "Reactific Software Inc.")),
-            Some(LiteralString((6, 12, rpi), "President"))
+            Some(LiteralString((6, 12, rpi), "President")),
+            None,None,Some(BlockDescription((7,18,rpi),
+              Seq(LiteralString((7,18,rpi),"identifying"))))
           )
-          domain.authors must contain(expectedAuthor)
+          domain.authors mustNot be(empty)
+          domain.authors.head must be(expectedAuthor)
           messages mustBe empty
       }
     }

--- a/testkit/src/test/scala/com/reactific/riddl/language/DomainValidatorTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/DomainValidatorTest.scala
@@ -30,7 +30,7 @@ class DomainValidatorTest extends ValidatingTest {
 
     "allow author information" in {
       val input = """domain foo is {
-                    |  author is {
+                    |  author Reid is {
                     |    name: "Reid Spencer"
                     |    email: "reid@reactific.com"
                     |    organization: "Reactific Software Inc."
@@ -42,14 +42,14 @@ class DomainValidatorTest extends ValidatingTest {
         (domain: Domain, rpi: RiddlParserInput, messages: ValidationMessages) =>
           domain mustNot be(empty)
           domain.contents mustBe empty
-          val expectedAuthor = Some(AuthorInfo(
-            (2, 3, rpi),
+          val expectedAuthor = AuthorInfo(
+            (2, 3, rpi), Identifier((2,10,rpi), "Reid"),
             LiteralString((3, 11, rpi), "Reid Spencer"),
             LiteralString((4, 12, rpi), "reid@reactific.com"),
             Some(LiteralString((5, 19, rpi), "Reactific Software Inc.")),
             Some(LiteralString((6, 12, rpi), "President"))
-          ))
-          domain.author mustBe expectedAuthor
+          )
+          domain.authors must contain(expectedAuthor)
           messages mustBe empty
       }
     }

--- a/testkit/src/test/scala/com/reactific/riddl/language/ParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ParserTest.scala
@@ -30,7 +30,7 @@ class ParserTest extends ParsingTest {
       }
     }
     "handle missing }" in {
-      val input = "domain foo is { author is { ??? }\n"
+      val input = "domain foo is { author nobody is { ??? }\n"
       parseTopLevelDomain(input, _.contents.head) match {
         case Left(errors) =>
           errors must not be empty

--- a/testkit/src/test/scala/com/reactific/riddl/language/TopLevelParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/TopLevelParserTest.scala
@@ -1,6 +1,6 @@
 package com.reactific.riddl.language
 
-import com.reactific.riddl.language.AST.{Domain, Identifier, RootContainer}
+import com.reactific.riddl.language.AST.{AuthorInfo, Domain, Identifier, RootContainer}
 import com.reactific.riddl.language.parsing.{RiddlParserInput, TopLevelParser}
 import com.reactific.riddl.language.testkit.ParsingTestBase
 
@@ -17,7 +17,7 @@ class TopLevelParserTest extends ParsingTestBase {
   val simpleDomain = RootContainer(List(Domain(
     Location(1, 1, rip),
     Identifier(Location(1, 8, rip), "foo"),
-    None,
+    Seq.empty[AuthorInfo],
     List(),
     List(),
     List(),


### PR DESCRIPTION
Allow multiple authors:
* Domains can now have multiple named author definitions, and
  they don't have to come first in the domain.

Fix Hugo Processing & Authors:
* Added options for the site title and description
* Removed the siteLogo option since it can just be put in
  the static directory instead of loaded from a URL
* Made riddlc actually read the "with" options for hugo cmd
* Always create the hugo output dir if it doesn't exist
* Handle the siteLogoPath option properly
* Simplify the function that generates the config.toml from a template

Update README:
* Add missing path element in Getting Started section of README
* Add instructions for using sbt-riddl plugin