### PR TITLE
Various Improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,70 +1,33 @@
 import com.jsuereth.sbtpgp.PgpKeys.pgpSigner
 
-import sbt.Keys.scalaVersion
 import sbtbuildinfo.BuildInfoOption.ToJson
 import sbtbuildinfo.BuildInfoOption.ToMap
 import sbtbuildinfo.BuildInfoOption.BuildTime
+import java.util.Calendar
 
-ThisBuild / maintainer := "reid@reactific.com"
-ThisBuild / organization := "com.reactific"
-ThisBuild / organizationHomepage := Some(new URL("https://reactific.com/"))
-ThisBuild / organizationName := "Ossum Inc."
-ThisBuild / startYear := Some(2019)
-ThisBuild / licenses +=
-  ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 (Global / excludeLintKeys) ++=
   Set(buildInfoPackage, buildInfoKeys, buildInfoOptions, mainClass, maintainer)
 
-ThisBuild / versionScheme := Option("semver-spec")
-ThisBuild / dynverVTagPrefix := false
 
-// NEVER  SET  THIS: version := "0.1"
-// IT IS HANDLED BY: sbt-dynver
-ThisBuild / dynverSeparator := "-"
-ThisBuild / scalaVersion := "2.13.8"
+lazy val riddl = (project in file("."))
+  .settings(
+    publish := {},
+    publishLocal := {},
+    pgpSigner / skip := true,
+    publishTo := Some(Resolver.defaultLocal),
+  )
+  .aggregate(
+    utils, language, testkit, hugo, `git-check`, prettify, examples,
+    doc, riddlc, `sbt-riddl`
+  )
 
-lazy val scala2_13_Options = Seq(
-  "-target:17",
-  // "-Ypatmat-exhaust-depth 40", Zinc can't handle this :(
-  "-Xsource:3",
-  "-Wdead-code",
-  "-deprecation",
-  "-feature",
-  "-Werror",
-  "-Wunused:imports", // Warn if an import selector is not referenced.
-  "-Wunused:patvars", // Warn if a variable bound in a pattern is unused.
-  "-Wunused:privates", // Warn if a private member is unused.
-  "-Wunused:locals", // Warn if a local definition is unused.
-  "-Wunused:explicits", // Warn if an explicit parameter is unused.
-  "-Wunused:implicits", // Warn if an implicit parameter is unused.
-  "-Wunused:params", // Enable -Wunused:explicits,implicits.
-  "-Xlint:nonlocal-return", // A return statement used an exception for flow control.
-  "-Xlint:implicit-not-found", // Check @implicitNotFound and @implicitAmbiguous messages.
-  "-Xlint:serial", // @SerialVersionUID on traits and non-serializable classes.
-  "-Xlint:valpattern", // Enable pattern checks in val definitions.
-  "-Xlint:eta-zero", // Warn on eta-expansion (rather than auto-application) of zero-ary method.
-  "-Xlint:eta-sam", // Warn on eta-expansion to meet a Java-defined functional
-  // interface that is not explicitly annotated with @FunctionalInterface.
-  "-Xlint:deprecation" // Enable linted deprecations.
-)
-
-lazy val riddl = (project in file(".")).settings(
-  publish := {},
-  publishLocal := {},
-  pgpSigner / skip := true,
-  publishTo := Some(Resolver.defaultLocal)
-).aggregate(
-  utils, language, testkit, hugo, `git-check`, prettify, examples,
-  doc, riddlc, `sbt-riddl`
-)
-
-lazy val utils = project.in(file("utils")).configure(C.withCoverage())
-  .configure(C.mavenPublish).enablePlugins(BuildInfoPlugin).settings(
+lazy val utils = project.in(file("utils")).configure(C.mavenPublish)
+  .configure(C.withCoverage())
+  .enablePlugins(BuildInfoPlugin).settings(
     name := "riddl-utils",
     coverageExcludedPackages := "<empty>",
-    scalacOptions := scala2_13_Options,
     maintainer := "reid@ossuminc.com",
     libraryDependencies ++= Seq(Dep.compress, Dep.lang3) ++ Dep.testing,
     buildInfoObject := "RiddlBuildInfo",
@@ -83,7 +46,12 @@ lazy val utils = project.in(file("utils")).configure(C.withCoverage())
       BuildInfoKey.map(homepage) { case (k, v) =>
         "projectHomepage" -> v.map(_.toString).getOrElse("https://riddl.tech")
       },
-      BuildInfoKey.map(startYear) { case (k, v) => k -> v.get.toString },
+      BuildInfoKey.map(startYear) { case (k, v) => k ->
+        v.map(_.toString).getOrElse("2019")
+      },
+      BuildInfoKey.map(startYear) { case (k, v) => "copyright" ->
+        s"© ${v.map(_.toString).getOrElse("2019")}-${
+          Calendar.getInstance().get(Calendar.YEAR)} Ossum Inc."},
       scalaVersion,
       sbtVersion,
       BuildInfoKey.map(licenses) { case (k, v) =>
@@ -97,7 +65,6 @@ lazy val language = project.in(file("language")).configure(C.withCoverage())
     name := "riddl-language",
     coverageExcludedPackages :=
       "<empty>;.*AST;.*BuildInfo;.*PredefinedType;.*Terminals.*",
-    scalacOptions := scala2_13_Options,
     libraryDependencies ++=
       Seq(Dep.fastparse, Dep.lang3, Dep.commons_io) ++ Dep.testing
   ).dependsOn(utils)
@@ -105,7 +72,6 @@ lazy val language = project.in(file("language")).configure(C.withCoverage())
 lazy val commands = project.in(file("commands")).configure(C.mavenPublish)
   .settings(
     name := "riddl-commands",
-    scalacOptions := scala2_13_Options,
     libraryDependencies ++= Seq(Dep.scopt, Dep.pureconfig) ++ Dep.testing
   )
   .dependsOn(utils % "compile->compile;test->test", language)
@@ -113,7 +79,6 @@ lazy val commands = project.in(file("commands")).configure(C.mavenPublish)
 lazy val testkit = project.in(file("testkit")).configure(C.mavenPublish)
   .settings(
     name := "riddl-testkit",
-    scalacOptions := scala2_13_Options,
     libraryDependencies ++= Dep.testKitDeps
   ).dependsOn(commands)
 
@@ -147,27 +112,38 @@ lazy val `git-check`: Project = project.in(file("git-check"))
     libraryDependencies ++= Seq(Dep.pureconfig, Dep.jgit) ++ Dep.testing
   ).dependsOn(hugo % "compile->compile;test->test")
 
-lazy val examples = project.in(file("examples")).settings(
-  name := "riddl-examples",
-  Compile / packageBin / publishArtifact := false,
-  Compile / packageDoc / publishArtifact := false,
-  Compile / packageSrc / publishArtifact := false,
-  publishTo := Option(Resolver.defaultLocal),
-  libraryDependencies ++=
-    Seq("org.scalatest" %% "scalatest" % "3.2.13" % "test")
-).dependsOn(hugo % "test->test", riddlc)
+lazy val examples = project.in(file("examples"))
+  .configure(C.withScalaCompile)
+  .settings(
+    name := "riddl-examples",
+    Compile / packageBin / publishArtifact := false,
+    Compile / packageDoc / publishArtifact := false,
+    Compile / packageSrc / publishArtifact := false,
+    publishTo := Option(Resolver.defaultLocal),
+    libraryDependencies ++=
+      Seq("org.scalatest" %% "scalatest" % "3.2.13" % "test")
+  ).dependsOn(hugo % "test->test", riddlc)
 
-lazy val doc = project.in(file("doc")).enablePlugins(SitePlugin)
-  .enablePlugins(SiteScaladocPlugin).configure(C.zipResource("hugo")).settings(
+lazy val doc = project.in(file("doc"))
+  .enablePlugins(SitePlugin, SiteScaladocPlugin, ScalaUnidocPlugin)
+  .configure(C.zipResource("hugo"))
+  .configure(C.withScalaCompile)
+  .settings(
     name := "riddl-doc",
     publishTo := Option(Resolver.defaultLocal),
     // Hugo / sourceDirectory := sourceDirectory.value / "hugo",
+    // siteSubdirName / ScalaUnidoc := "api",
+    // (mappings / (
+    //   ScalaUnidoc, packageDoc), siteSubdirName in ScalaUnidoc
+    // ),
     publishSite
   ).dependsOn(hugo % "test->test", riddlc)
 
 lazy val riddlc: Project = project.in(file("riddlc"))
   .enablePlugins(JavaAppPackaging, UniversalDeployPlugin)
-  .enablePlugins(MiniDependencyTreePlugin).configure(C.mavenPublish).dependsOn(
+  .enablePlugins(MiniDependencyTreePlugin).configure(C.mavenPublish)
+  .configure(C.withCoverage())
+  .dependsOn(
     utils % "compile->compile;test->test",
     commands,
     language,
@@ -176,7 +152,6 @@ lazy val riddlc: Project = project.in(file("riddlc"))
   ).settings(
     name := "riddlc",
     mainClass := Option("com.reactific.riddl.RIDDLC"),
-    scalacOptions := scala2_13_Options,
     libraryDependencies ++= Seq(Dep.pureconfig) ++ Dep.testing
   )
 

--- a/commands/src/main/scala/com/reactific/riddl/commands/CommandPlugin.scala
+++ b/commands/src/main/scala/com/reactific/riddl/commands/CommandPlugin.scala
@@ -143,7 +143,7 @@ abstract class CommandPlugin[OPT <: CommandOptions : ClassTag](
    * reader should read an object having the same name as the command. The fields
    * of that object must correspond to the fields of the OPT type.
    * @param log A logger to use for output (discouraged)
-   * @return A [[pureconfig.ConfigReader]] that knows how to read OPT
+   * @return A pureconfig.ConfigReader[OPT] that knows how to read OPT
    */
   def getConfigReader() : ConfigReader[OPT]
 

--- a/commands/src/main/scala/com/reactific/riddl/commands/RepeatCommand.scala
+++ b/commands/src/main/scala/com/reactific/riddl/commands/RepeatCommand.scala
@@ -88,14 +88,7 @@ class RepeatCommand extends CommandPlugin[RepeatCommand.Options](
       ) -> Options()
   }
 
-  /**
-   * Provide a typesafe/Config reader for the commands options. This
-   * reader should read an object having the same name as the command. The fields
-   * of that object must correspond to the fields of the OPT type.
-   *
-   * @param log A logger to use for output (discouraged)
-   * @return A [[pureconfig.ConfigReader]] that knows how to read OPT
-   */
+
   override def getConfigReader(): ConfigReader[Options] = ???
 
   def allowCancel(options: Options): (Future[Boolean], () => Boolean) = {

--- a/commands/src/main/scala/com/reactific/riddl/commands/TranslationCommand.scala
+++ b/commands/src/main/scala/com/reactific/riddl/commands/TranslationCommand.scala
@@ -45,8 +45,8 @@ abstract class TranslationCommand[OPT <: TranslationCommand.Options : ClassTag](
    * been parsed and validated already so the job is to translate the root
    * argument into the directory of files.
    *
-   * @param root The [[RootContainer]] providing the parsed/validated input
-   * @param log A [[Logger]] to use for messages. Use sparingly, not for errors
+   * @param root The RootContainer providing the parsed/validated input
+   * @param log A Logger to use for messages. Use sparingly, not for errors
    * @param commonOptions The options common to all commands
    * @param options The options specific to your subclass implementation
    * @return A Right[Unit] if successful or Left[Messages] if not

--- a/doc/src/hugo/content/audience/developers-guide/releasing.md
+++ b/doc/src/hugo/content/audience/developers-guide/releasing.md
@@ -8,32 +8,36 @@ weight: 999
 This is a "how to" guide on releasing the software. 
 
 ## Build & Test
+Make sure everything tests correctly from a clean start. 
 ```shell
 > cd riddl # top level directory of repository 
 > sbt "clean ; test"
 ...
 [info] All tests passed.
 ```
-
 If all tests do not pass, stop and fix the software
 
-## Set Version
-1. Pick a version number, x.y.z, based on current version and 
-   [semantic versioning rules](https://semver.org/)
-2. Formulate a short description string for the release, call it desc 
+## Stage
 ```shell
-% sbt
+> sbt stage
+...
+[info] Main Scala API documentation successful.
+[success] Total time: 29 s, completed Sep 5, 2022, 12:05:58 PM
+```
+If this task does not successfully complete, stop and fix the documentation which
+is likely to be references to Scala classes in the docs between `[[` and `]]`
+
+## Set Version
+Now that you've got things working, pick a version number and tag it:
+1. Pick a version number, x.y.z, based on current tagged version and 
+   [semantic versioning rules](https://semver.org/)
+2. Formulate a short description string for the release
+3. Run this:
+```shell
 > git tag -a ${x.y.z} -m "${release description}"
-> reload
-> show version
+> sbt show version # confirm it is the version you just set
 > git push --tags
 ```
-{{% hint warning "Running From SBT" %}}
-When you run the git commands from the SBT command prompt, you must 
-reload in order to get the correct build version number into the artifacts.
-Failing to do this will attempt to release a snapshot version which won't 
-go well for you.
-{{% /hint %}}
 
 ## Release To Maven
 1. First, publish the artifacts to oss.sonatype.org

--- a/git-check/src/main/scala/com/reactific/riddl/translator/hugo_git_check/GitCheckCommand.scala
+++ b/git-check/src/main/scala/com/reactific/riddl/translator/hugo_git_check/GitCheckCommand.scala
@@ -34,14 +34,14 @@ class GitCheckCommand extends CommandPlugin[GitCheckCommand.Options](
     OParser.sequence(cmd("git-check")
       .children(
         opt[File]("git-clone-dir")
-          .required
+          .required()
           .action( (f,opts) => opts.copy(gitCloneDir = Some(f.toPath)))
           .text(
             """Provides the top directory of a git repo clone that
               |contains the <input-file> to be processed.""".stripMargin
           ),
         opt[String]("user-name")
-          .optional
+          .optional()
           .action( (n,opts) => opts.copy(userName = n))
           .text("Name of the git user for pulling from remote"),
         opt[String]("access-token")

--- a/hugo/src/main/scala/com/reactific/riddl/hugo/HugoCommand.scala
+++ b/hugo/src/main/scala/com/reactific/riddl/hugo/HugoCommand.scala
@@ -27,7 +27,6 @@ import scopt.OParser
 
 import java.net.URL
 import java.nio.file.Path
-import scala.util.control.NonFatal
 
 /** Unit Tests For HugoCommand */
 object HugoCommand {

--- a/hugo/src/main/scala/com/reactific/riddl/hugo/MarkdownWriter.scala
+++ b/hugo/src/main/scala/com/reactific/riddl/hugo/MarkdownWriter.scala
@@ -19,7 +19,9 @@ package com.reactific.riddl.hugo
 import com.reactific.riddl.language.AST
 import com.reactific.riddl.language.AST._
 import com.reactific.riddl.utils.TextFileWriter
+
 import java.nio.file.Path
+import scala.annotation.unused
 
 case class MarkdownWriter(
   filePath: Path,
@@ -318,7 +320,7 @@ case class MarkdownWriter(
   def emitBriefly(
     d: Definition,
     parents: Seq[String],
-    level: Int = 2
+    @unused level: Int = 2
   ): this.type = {
     emitTableHead(Seq("Item" -> 'C', "Value" -> 'L'))
     emitTableRow("_Briefly_", d.brief.fold("Brief description missing.\n")(_.s))

--- a/project/Helpers.scala
+++ b/project/Helpers.scala
@@ -1,32 +1,32 @@
+import com.typesafe.sbt.packager.Keys.maintainer
 import sbt.Keys._
-
 import sbt._
 import sbt.io.Path.allSubpaths
 import scoverage.ScoverageKeys.coverageEnabled
 import scoverage.ScoverageKeys.coverageFailOnMinimum
 import scoverage.ScoverageKeys.coverageMinimumBranchTotal
 import scoverage.ScoverageKeys.coverageMinimumStmtTotal
-import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
-import sbtdynver.DynVerPlugin.autoImport.dynverSeparator
+import sbtdynver.DynVerPlugin.autoImport.{
+  dynverSeparator, dynverSonatypeSnapshots, dynverVTagPrefix
+}
 
 /** V - Dependency Versions object */
 object V {
-  val cats = "2.7.0"
+  val cats = "2.8.0"
   val commons_io = "2.11.0"
   val compress = "1.21"
-  val config = "1.4.1"
+  val config = "1.4.2"
   val fastparse = "2.3.3"
   val jgit = "6.2.0.202206071550-r"
   val lang3 = "3.12.0"
   val pureconfig = "0.17.1"
   val scalacheck = "1.16.0"
-  val scalatest = "3.2.9"
+  val scalatest = "3.2.12"
   val scopt = "4.1.0"
-  val ujson = "1.5.0"
+  val ujson = "2.0.0"
 }
 
 object Dep {
-  val cats_core = "org.typelevel" %% "cats-core" % V.cats
   val compress = "org.apache.commons" % "commons-compress" % V.compress
   val commons_io = "commons-io" % "commons-io" % V.commons_io
   val config = "com.typesafe" % "config" % V.config
@@ -38,14 +38,77 @@ object Dep {
   val scalatest = "org.scalatest" %% "scalatest" % V.scalatest
   val scalacheck = "org.scalacheck" %% "scalacheck" % V.scalacheck
   val scopt = "com.github.scopt" %% "scopt" % V.scopt
-  val ujson = "com.lihaoyi" %% "ujson" % V.ujson
 
-  val testing = Seq(scalactic % "test", scalatest % "test", scalacheck % "test")
-  val testKitDeps = Seq(scalactic, scalatest, scalacheck)
+  val testing: Seq[ModuleID] = Seq(
+    scalactic % "test", scalatest % "test", scalacheck % "test"
+  )
+  val testKitDeps: Seq[ModuleID] = Seq(scalactic, scalatest, scalacheck)
 
 }
 
 object C {
+  def withInfo(p: Project): Project = {
+    p.settings(
+      ThisBuild / maintainer := "reid@reactific.com",
+      ThisBuild / organization := "com.reactific",
+      ThisBuild / organizationHomepage := Some(new URL("https://reactific.com/")),
+      ThisBuild / organizationName := "Ossum Inc.",
+      ThisBuild / startYear := Some(2019),
+      ThisBuild / licenses += ("Apache-2.0",
+        new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+      ThisBuild / versionScheme := Option("semver-spec"),
+      ThisBuild / dynverVTagPrefix := false,
+      // NEVER  SET  THIS: version := "0.1"
+      // IT IS HANDLED BY: sbt-dynver
+      ThisBuild / dynverSeparator := "-"
+    )
+  }
+
+  lazy val scala3_2_Options: Seq[String] = Seq(
+    "-deprecation",
+    "-feature",
+    "-Werror"
+  )
+  lazy val scala2_13_Options: Seq[String] = Seq(
+    "-target:17",
+    // "-Ypatmat-exhaust-depth 40", Zinc can't handle this :(
+    "-Xsource:3",
+    "-Wdead-code",
+    "-deprecation",
+    "-feature",
+    "-Werror",
+    "-Wunused:imports", // Warn if an import selector is not referenced.
+    "-Wunused:patvars", // Warn if a variable bound in a pattern is unused.
+    "-Wunused:privates", // Warn if a private member is unused.
+    "-Wunused:locals", // Warn if a local definition is unused.
+    "-Wunused:explicits", // Warn if an explicit parameter is unused.
+    "-Wunused:implicits", // Warn if an implicit parameter is unused.
+    "-Wunused:params", // Enable -Wunused:explicits,implicits.
+    "-Xlint:nonlocal-return", // A return statement used an exception for flow control.
+    "-Xlint:implicit-not-found", // Check @implicitNotFound and @implicitAmbiguous messages.
+    "-Xlint:serial", // @SerialVersionUID on traits and non-serializable classes.
+    "-Xlint:valpattern", // Enable pattern checks in val definitions.
+    "-Xlint:eta-zero", // Warn on eta-expansion (rather than auto-application) of zero-ary method.
+    "-Xlint:eta-sam", // Warn on eta-expansion to meet a Java-defined functional
+    // interface that is not explicitly annotated with @FunctionalInterface.
+    "-Xlint:deprecation" // Enable linted deprecations.
+  )
+
+  def withScalaCompile(p:Project): Project = {
+    p.configure(withInfo)
+      .settings(
+        scalaVersion := "2.13.8",
+        scalacOptions := {
+          if (scalaVersion.value.startsWith("3.2"))
+            scala3_2_Options
+          else if (scalaVersion.value.startsWith("2.13")) {
+            scala2_13_Options
+          } else
+            Seq.empty[String]
+        }
+    )
+  }
+
   def withCoverage(enabled: Boolean = false)(p: Project): Project = {
     p.settings(
       coverageEnabled := enabled,
@@ -81,7 +144,7 @@ object C {
   }
 
   def mavenPublish(p: Project): Project = {
-    p.settings(
+    p.configure(withScalaCompile).settings(
       ThisBuild / dynverSonatypeSnapshots := true,
       ThisBuild / dynverSeparator := "-",
       organization := "com.reactific",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
-
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/riddlc/src/main/scala/com/reactific/riddl/HelpCommand.scala
+++ b/riddlc/src/main/scala/com/reactific/riddl/HelpCommand.scala
@@ -47,7 +47,7 @@ class HelpCommand extends CommandPlugin[HelpCommand.Options]("help") {
     commonOptions: CommonOptions,
     log: Logger
   ): Either[Messages, Unit] = {
-    log.info(RiddlOptions.usage)
+    println(RiddlOptions.usage)
     Right(())
   }
 }

--- a/riddlc/src/main/scala/com/reactific/riddl/InfoCommand.scala
+++ b/riddlc/src/main/scala/com/reactific/riddl/InfoCommand.scala
@@ -50,6 +50,7 @@ class InfoCommand extends CommandPlugin[InfoCommand.Options]("info") {
     log.info("About riddlc:")
     log.info(s"           name: ${RiddlBuildInfo.name}")
     log.info(s"        version: ${RiddlBuildInfo.version}")
+    log.info(s"      copyright: ${RiddlBuildInfo.copyright}")
     log.info(s"     start year: ${RiddlBuildInfo.startYear}")
     log.info(s"       built at: ${RiddlBuildInfo.builtAtString}")
     log.info(s"       licenses: ${RiddlBuildInfo.licenses}")

--- a/riddlc/src/test/scala/com/reactific/riddl/RiddlCommandsTest.scala
+++ b/riddlc/src/test/scala/com/reactific/riddl/RiddlCommandsTest.scala
@@ -6,33 +6,9 @@ import com.reactific.riddl.utils.SysLogger
 import org.scalatest.Assertion
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import scopt.OParser
 
 class RiddlCommandsTest extends AnyWordSpec with Matchers {
 
-  def runSimpleCommand(command: String): Assertion = {
-    CommandPlugin.loadCommandNamed(command) match {
-      case Right(cmd) =>
-        val args = Array(command)
-        val log = SysLogger()
-        val (parser, default) = cmd.getOptions()
-        val (result, _) = OParser.runParser(parser, args, default)
-        result match {
-          case Some(options) =>
-            cmd.run(options, CommonOptions(), log) match {
-              case Right(_) =>
-                succeed
-              case Left(errors) =>
-                fail(errors.format)
-            }
-          case None =>
-            fail("Parsing options failed")
-        }
-      case Left(errors) =>
-        fail(errors.format)
-    }
-
-  }
   "Riddlc Commands" should {
     "generate info" in {
       runSimpleCommand("info")
@@ -44,4 +20,18 @@ class RiddlCommandsTest extends AnyWordSpec with Matchers {
       runSimpleCommand("version")
     }
   }
+
+  def runSimpleCommand(
+    command: String,
+    args: Array[String] = Array.empty[String]
+  ): Assertion = {
+    val log = SysLogger()
+    CommandPlugin.runCommandWithArgs(command,args, log, CommonOptions()) match {
+      case Right(_) =>
+        succeed
+      case Left(errors) =>
+        fail(errors.format)
+    }
+  }
+
 }

--- a/testkit/src/main/scala/com/reactific/riddl/language/testkit/RunCommandOnExamplesTest.scala
+++ b/testkit/src/main/scala/com/reactific/riddl/language/testkit/RunCommandOnExamplesTest.scala
@@ -72,9 +72,8 @@ abstract class RunCommandOnExamplesTest[
   private final val suffix = "conf"
 
   def forEachConfigFile[T](f : (String, Path) => T): Seq[Either[Messages,T]] = {
-    val configs = FileUtils
-      .iterateFiles(srcDir.toFile, Array[String](suffix),true)
-      .asScala.toSeq
+    val configs = FileUtils.iterateFiles(
+      srcDir.toFile, Array[String](suffix),true).asScala.toSeq
     for {
       config <- configs
     } yield {


### PR DESCRIPTION
* Make the `help` output more readable
* Include "copyright" in the BuildInfo
* Use "copyright" in the `info` command
* Simplify build.sbt
* Remove unworkable code references in doc comments
* Update the releasing.md file to use "stage" command earlly to find
  documentation issues.
* Prepare for Scala 3.2 upgrade (waiting on fastparse)
* Apply scala options consistently across project
* Fix syntax errors from -xsource:3 option
* Add the sbt-unidoc plugin
*