### PR TITLE
Make Expressions Typed

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/AST.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/AST.scala
@@ -29,8 +29,7 @@ import com.reactific.riddl.language.parsing.RiddlParserInput
   * which is referentially and semantically consistent (or the user gets an
   * error).
   */
-object AST
-    extends ast.Expressions with ast.TypeExpression with parsing.Terminals {
+object AST extends ast.Expressions with parsing.Terminals {
 
   /** Base trait of any definition that is a container and contains types
     */
@@ -262,7 +261,10 @@ object AST
     * @param args
     *   An argument list that should correspond to teh fields of the message
     */
-  case class MessageConstructor(msg: MessageRef, args: ArgList = ArgList())
+  case class MessageConstructor(
+    loc: Location,
+    msg: MessageRef,
+    args: ArgList = ArgList())
       extends RiddlNode {
     override def format: String = msg.format + {
       if (args.nonEmpty) { args.format }

--- a/language/src/main/scala/com/reactific/riddl/language/Validation.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/Validation.scala
@@ -1146,16 +1146,8 @@ object Validation {
 
     def getExpressionType(expr: Expression): Option[TypeExpression] = {
       expr match {
-        case ne: NumericExpression => ne match {
-            case LiteralInteger(loc, _)        => Some(Integer(loc))
-            case LiteralDecimal(loc, _)        => Some(Decimal(loc))
-            case ArithmeticOperator(loc, _, _) => Some(Number(loc))
-          }
-        case cond: Condition                    => Some(Bool(cond.loc))
         case EntityIdExpression(loc, pid)       => Some(UniqueId(loc, pid))
         case ValueExpression(_, path)           => getPathIdType(path)
-        case ae: ArbitraryExpression            => Some(Abstract(ae.loc))
-        case ao: ArbitraryOperator              => Some(Abstract(ao.loc))
         case FunctionCallExpression(_, name, _) => getPathIdType(name)
         case GroupExpression(loc, expressions)  =>
           // the type of a group is the last expression but it could be empty
@@ -1163,7 +1155,6 @@ object Validation {
             case None       => Some(Abstract(loc))
             case Some(expr) => getExpressionType(expr)
           }
-        case UndefinedExpression(loc)                   => Some(Abstract(loc))
         case AggregateConstructionExpression(_, pid, _) => getPathIdType(pid)
         case Ternary(loc, _, expr1, expr2) =>
           val expr1Ty = getExpressionType(expr1)
@@ -1180,6 +1171,7 @@ object Validation {
             )
             None
           }
+        case e: Expression => Some(e.expressionType)
       }
     }
 
@@ -1229,7 +1221,7 @@ object Validation {
                   unset.filterNot(_.isImplicit).foldLeft(state) {
                     (next, field) =>
                       next.addError(
-                        field.loc,
+                        messageConstructor.loc,
                         s"${field.identify} was not set in message constructor"
                       )
                   }

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ActionParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ActionParser.scala
@@ -32,8 +32,8 @@ trait ActionParser extends ReferenceParser with ExpressionParser {
   }
 
   def errorAction[u: P]: P[ErrorAction] = {
-    P(location ~ Keywords.error ~ literalString ~ description).map {
-      tpl => (ErrorAction.apply _).tupled(tpl)
+    P(location ~ Keywords.error ~ literalString ~ description).map { tpl =>
+      (ErrorAction.apply _).tupled(tpl)
     }
   }
 
@@ -46,11 +46,10 @@ trait ActionParser extends ReferenceParser with ExpressionParser {
 
   def appendAction[u: P]: P[AppendAction] = {
     P(
-      location ~ Keywords.append ~/ expression ~ Readability.to ~ pathIdentifier
-        ~ description
+      location ~ Keywords.append ~/ expression ~ Readability.to ~
+        pathIdentifier ~ description
     ).map { t => (AppendAction.apply _).tupled(t) }
   }
-
 
   def morphAction[u: P]: P[MorphAction] = {
     P(
@@ -67,7 +66,8 @@ trait ActionParser extends ReferenceParser with ExpressionParser {
   }
 
   def messageConstructor[u: P]: P[MessageConstructor] = {
-    P(messageRef ~ argList).map(tpl => (MessageConstructor.apply _).tupled(tpl))
+    P(location ~ messageRef ~ argList)
+      .map(tpl => (MessageConstructor.apply _).tupled(tpl))
   }
 
   def returnAction[u: P]: P[ReturnAction] = {
@@ -82,8 +82,8 @@ trait ActionParser extends ReferenceParser with ExpressionParser {
 
   def publishAction[u: P]: P[PublishAction] = {
     P(
-      Keywords.publish ~/ location ~ messageConstructor ~
-        Readability.to ~ pipeRef ~ description
+      Keywords.publish ~/ location ~ messageConstructor ~ Readability.to ~
+        pipeRef ~ description
     ).map { t => (PublishAction.apply _).tupled(t) }
   }
 

--- a/testkit/src/test/scala/com/reactific/riddl/language/ConditionParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ConditionParserTest.scala
@@ -42,8 +42,10 @@ class ConditionParserTest extends ParsingTest {
     }
     "accept literal string" in {
       parseCondition("\"decide\"") { cond: Condition =>
-        cond mustBe
-          ArbitraryCondition(LiteralString(Location(1 -> 1), "decide"))
+        cond mustBe ArbitraryCondition(
+          Location(1 -> 1),
+          LiteralString(Location(1 -> 1), "decide")
+        )
       }
     }
     "accept and(true,false)" in {
@@ -127,7 +129,7 @@ class ConditionParserTest extends ParsingTest {
                   Comparison(
                     1 -> 12,
                     AST.eq,
-                    ArbitraryCondition(LiteralString(1 -> 15, "sooth")),
+                    ArbitraryCondition(1->15, LiteralString(1 -> 15, "sooth")),
                     False(1 -> 24)
                   )
                 ),

--- a/testkit/src/test/scala/com/reactific/riddl/language/ExpressionParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ExpressionParserTest.scala
@@ -103,7 +103,7 @@ class ExpressionParserTest extends ParsingTest {
     }
     "accept pow abstract binary" in {
       parseExpression("pow(2,3)") { expr: Expression =>
-        expr mustBe ArithmeticOperator(
+        expr mustBe NumberFunction(
           Location(1 -> 1),
           "pow",
           Seq(
@@ -127,17 +127,11 @@ class ExpressionParserTest extends ParsingTest {
         )
       }
     }
-    "accept arithmetic expression with 0 number of args" in {
-      parseExpression("now()") { expr: Expression =>
-        expr mustBe
-          ArithmeticOperator(Location(1 -> 1), "now", Seq.empty[Expression])
-      }
-    }
     "accept arbitrary expression with many  args" in {
       parseExpression("wow(0,0,0,0,0,0)") { expr: Expression =>
         expr mustBe ArbitraryOperator(
           Location(1 -> 1),
-          LiteralString(1->1,"wow"),
+          LiteralString(1 -> 1, "wow"),
           Seq(
             LiteralInteger(Location(1 -> 5), 0),
             LiteralInteger(Location(1 -> 7), 0),
@@ -164,6 +158,25 @@ class ExpressionParserTest extends ParsingTest {
         )
       }
     }
-
+    "accept the now() operator" in {
+      parseExpression("now()") { expr: Expression =>
+        expr mustBe TimeStampFunction(1 -> 1, "now", Seq.empty[Expression])
+      }
+    }
+    "accept the today() operator" in {
+      parseExpression("today()") { expr: Expression =>
+        expr mustBe DateFunction(1 -> 1, "today", Seq.empty[Expression])
+      }
+    }
+    "accept the random() operator" in {
+      parseExpression("random()") { expr: Expression =>
+        expr mustBe NumberFunction(1 -> 1, "random", Seq.empty[Expression])
+      }
+    }
+    "accept the length() operator" in {
+      parseExpression("length()") { expr: Expression =>
+        expr mustBe StringFunction(1 -> 1, "length", Seq.empty[Expression])
+      }
+    }
   }
 }

--- a/testkit/src/test/scala/com/reactific/riddl/language/ParserTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/language/ParserTest.scala
@@ -213,6 +213,7 @@ class ParserTest extends ParsingTest {
             (1, 11, rpi),
             Identifier((1, 11, rpi), "large"),
             Some(ArbitraryCondition(
+              (1, 22, rpi),
               LiteralString((1, 22, rpi), "x is greater or equal to 10")
             )),
             None
@@ -276,6 +277,7 @@ class ParserTest extends ParsingTest {
                 Seq(WhenClause(
                   (9, 7, rpi),
                   ArbitraryCondition(
+                    (9, 12, rpi),
                     LiteralString((9, 12, rpi), "I go fishing")
                   )
                 )),


### PR DESCRIPTION
* Add an expressionType member to each expression
* Default the expressionType for each expression
* In validation, use defaults except when PathIdentifiers are used
* Specify a few well-known and typed expressions
* Various other fixes