### PR TITLE
#329 Revise projection parsing

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/Folding.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/Folding.scala
@@ -218,7 +218,7 @@ object Folding {
                 // what we are looking for
                 fields
               case Enumeration(_, enumerators) => enumerators
-              case MessageType(_, _, fields)   =>
+              case AggregateUseCaseTypeExpression(_, _, fields)   =>
                 // Message types have fields too, those fields are what we seek
                 fields
               case AliasedTypeExpression(_, pid) =>
@@ -232,7 +232,7 @@ object Folding {
           case t: Type => t.typ match {
               case Aggregation(_, fields)        => fields
               case Enumeration(_, enumerators)   => enumerators
-              case MessageType(_, _, fields)     => fields
+              case AggregateUseCaseTypeExpression(_, _, fields)     => fields
               case AliasedTypeExpression(_, pid) =>
                 // if we're at a type definition that references another type then
                 // we need to push that type's path on the name stack

--- a/language/src/main/scala/com/reactific/riddl/language/Validation.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/Validation.scala
@@ -344,7 +344,7 @@ object Validation {
       parents: Seq[Definition]
     ): ValidationState = { checkContainer(parents, h).checkDescription(h) }
 
-    def validateOnClause(
+    private def validateOnClause(
       oc: OnClause,
       parents: Seq[Definition]
     ): ValidationState = {
@@ -359,7 +359,7 @@ object Validation {
       }).checkDescription(oc)
     }
 
-    def validateInclude[T <: Definition](i: Include[T]): ValidationState = {
+    private def validateInclude[T <: Definition](i: Include[T]): ValidationState = {
       check(i.nonEmpty, "Include has no included content", Error, i.loc)
         .check(i.path.nonEmpty, "Include has no path provided", Error, i.loc)
         .step { s =>
@@ -374,7 +374,7 @@ object Validation {
         }
     }
 
-    def validateEntity(e: Entity, parents: Seq[Definition]): ValidationState = {
+    private def validateEntity(e: Entity, parents: Seq[Definition]): ValidationState = {
       this.entities = this.entities :+ e
       checkContainer(parents, e).checkOptions[EntityOption](e.options, e.loc)
         .addIf(e.states.isEmpty && !e.isEmpty) {
@@ -399,7 +399,7 @@ object Validation {
         }.checkDescription(e)
     }
 
-    def validateProjection(
+    private def validateProjection(
       p: Projection,
       parents: Seq[Definition]
     ): ValidationState = {
@@ -415,22 +415,11 @@ object Validation {
         s"${p.identify} must have exactly one Handler but has ${p.handlers.length}", Error, p.loc)
     }
 
-
-    def checkAggregation(
-                          aggregation: Option[Aggregation]
-                        ): ValidationState = {
-      aggregation match {
-        case None => this
-        case Some(aggregation) => checkAggregation(aggregation)
-      }
-    }
-
-
-    def validateRepository(
+    private def validateRepository(
       r: Repository,
       parents: Seq[Definition]
     ): ValidationState = { checkContainer(parents, r).checkDescription(r) }
-    def validateAdaptor(
+    private def validateAdaptor(
       a: Adaptor,
       parents: Seq[Definition]
     ): ValidationState = {

--- a/language/src/main/scala/com/reactific/riddl/language/ast/TypeExpression.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/TypeExpression.scala
@@ -50,7 +50,7 @@ trait TypeExpression extends AbstractDefinitions {
         s"Reference to entity ${entity.format}"
       case _: Pattern              => Predefined.Pattern
       case UniqueId(_, entityPath) => s"Id(${entityPath.format})"
-      case m @ MessageType(_, messageKind, _) =>
+      case m @ AggregateUseCaseTypeExpression(_, messageKind, _) =>
         s"${messageKind.format} of ${m.fields.size} fields"
       case pt: PredefinedType => pt.kind
       case _                  => "<unknown type expression>"
@@ -60,32 +60,36 @@ trait TypeExpression extends AbstractDefinitions {
   // //////////////////////////////////////////////////////////////////////// TYPES
 
   /** Base of an enumeration for the four kinds of message types */
-  sealed trait MessageKind {
+  sealed trait AggregateUseCase {
     @inline def kind: String
     def format: String = kind.capitalize
   }
 
   /** An enumerator value for command types */
-  final case object CommandKind extends MessageKind {
+  final case object CommandCase extends AggregateUseCase {
     @inline def kind: String = "command"
   }
 
   /** An enumerator value for event types */
-  final case object EventKind extends MessageKind {
+  final case object EventCase extends AggregateUseCase {
     @inline def kind: String = "event"
   }
 
   /** An enumerator value for query types */
-  final case object QueryKind extends MessageKind {
+  final case object QueryCase extends AggregateUseCase {
     @inline def kind: String = "query"
   }
 
   /** An enumerator value for result types */
-  final case object ResultKind extends MessageKind {
+  final case object ResultCase extends AggregateUseCase {
     @inline def kind: String = "result"
   }
 
-  final case object OtherKind extends MessageKind {
+  final case object RecordCase extends AggregateUseCase {
+    @inline def kind: String = "record"
+  }
+
+  final case object OtherCase extends AggregateUseCase {
     @inline def kind: String = "other"
   }
 
@@ -348,22 +352,23 @@ trait TypeExpression extends AbstractDefinitions {
     }
   }
 
-  /** A type expression for an aggregation type expression that is marked as
-    * being one of the four message kinds.
+  /** A type expression for an aggregation that is marked as
+    * being one of the use cases. This is used for messages, records, and
+    * other aggregate types that need to have their purpose distinguished.
     *
     * @param loc
     *   The location of the message type expression
-    * @param messageKind
+    * @param usecase
     *   The kind of message defined
     * @param fields
     *   The fields of the message's aggregation
     */
-  case class MessageType(
-    loc: At,
-    messageKind: MessageKind,
-    fields: Seq[Field] = Seq.empty[Field])
-      extends AggregateTypeExpression {
-    override def format: String = { messageKind.kind + " " + super.format }
+  case class AggregateUseCaseTypeExpression(
+                                             loc: At,
+                                             usecase: AggregateUseCase,
+                                             fields: Seq[Field] = Seq.empty[Field]
+  ) extends AggregateTypeExpression {
+    override def format: String = { usecase.format + " " + super.format }
   }
 
   /** Base class of all pre-defined type expressions

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ProjectionParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ProjectionParser.scala
@@ -30,12 +30,12 @@ trait ProjectionParser extends TypeParser with HandlerParser {
   }
 
   type ProjectionBody =
-    (Seq[ProjectionOption], Option[Aggregation], Seq[ProjectionDefinition])
+    (Seq[ProjectionOption], Seq[Type], Seq[ProjectionDefinition])
   def projectionBody[u: P]: P[ProjectionBody] = {
     P(
       undefined(
-        (Seq.empty[ProjectionOption], None, Seq.empty[ProjectionDefinition])
-      ) | (projectionOptions ~ aggregation.? ~ projectionDefinitions)
+        (Seq.empty[ProjectionOption], Seq.empty[Type], Seq.empty[ProjectionDefinition])
+      ) | (projectionOptions ~ typeDef.rep(0) ~ projectionDefinitions)
     )
   }
 
@@ -57,7 +57,7 @@ trait ProjectionParser extends TypeParser with HandlerParser {
             loc,
             id,
             authors,
-            (options, aggregation, definitions),
+            (options, types, definitions),
             briefly,
             description
           ) =>
@@ -74,7 +74,7 @@ trait ProjectionParser extends TypeParser with HandlerParser {
           authors,
           options,
           includes,
-          aggregation,
+          types,
           handlers,
           invariants,
           terms,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/Terminals.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/Terminals.scala
@@ -175,6 +175,7 @@ trait Terminals {
     final val repository = "repository"
     final val requires = "requires"
     final val required = "required"
+    final val record = "record"
     final val result = "result"
     final val results = "results"
     final val return_ = "return"

--- a/language/src/test/scala/com/reactific/riddl/language/ContextValidationTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/ContextValidationTest.scala
@@ -134,17 +134,23 @@ class ContextValidationTest extends ValidatingTest {
       }
     }
     "allow projections" in {
-      val input = """projection foo is { ??? }
+      val input = """projection foo is {
+                    |  record one is { ??? }
+                    |  handler one is { ??? }
+                    |}
                     |""".stripMargin
       parseAndValidateContext(input) {
         case (context: Context, rpi, msgs: Messages) =>
           val errors = msgs.justErrors
           info(errors.format)
           errors must be(empty)
-          val expected =
-            Projection((2, 2, rpi), Identifier((2, 13, rpi), "foo"))
           context.projections.size mustBe (1)
-          context.projections.head mustBe expected
+          val actual = context.projections.head
+          val expected =
+            Projection((2,2,rpi),Identifier((2,13,rpi),"foo"),List(),List(),List(),
+              List(Type((3,3,rpi),Identifier((3,10,rpi),"one"),AggregateUseCaseTypeExpression((3,17,rpi),RecordCase,List()),None,None)),
+              List(Handler((4,11,rpi),Identifier((4,11,rpi),"one"),List(),List(),None,None)),List(),List(),None,None)
+          actual mustBe expected
       }
     }
 

--- a/language/src/test/scala/com/reactific/riddl/language/StoryTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/StoryTest.scala
@@ -82,6 +82,7 @@ class StoryTest extends ValidatingTest {
           |
           |  projection OrganizationViews is {
           |   record SimpleView { a: Integer}
+          |   handler Simple { ??? }
           |   term xyz
           |   brief "y"
           |  } described as "nada"
@@ -154,6 +155,7 @@ class StoryTest extends ValidatingTest {
           |
           |  projection OrganizationViews is {
           |   record SimpleView { a: Integer}
+          |   handler Simple { ??? }
           |   term xyz
           |   brief "y"
           |  } described as "nada"
@@ -226,6 +228,7 @@ class StoryTest extends ValidatingTest {
           |
           |  projection OrganizationViews is {
           |   record SimpleView { a: Integer}
+          |   handler Simple { ??? }
           |   term xyz
           |   brief "y"
           |  } described as "nada"

--- a/language/src/test/scala/com/reactific/riddl/language/StoryTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/StoryTest.scala
@@ -80,7 +80,11 @@ class StoryTest extends ValidatingTest {
           |
           |  entity Organization is { ??? } described as "nada"
           |
-          |  projection OrganizationViews is { fields { a: Integer} term xyz brief "y" } described as "nada"
+          |  projection OrganizationViews is {
+          |   record SimpleView { a: Integer}
+          |   term xyz
+          |   brief "y"
+          |  } described as "nada"
           |} described as "nada"
           |
           |application Improving_app is {
@@ -148,7 +152,11 @@ class StoryTest extends ValidatingTest {
           |
           |  entity Organization is { ??? } described as "nada"
           |
-          |  projection OrganizationViews is { fields { a: Integer} term xyz brief "y" } described as "nada"
+          |  projection OrganizationViews is {
+          |   record SimpleView { a: Integer}
+          |   term xyz
+          |   brief "y"
+          |  } described as "nada"
           |} described as "nada"
           |
           |application Improving_app is {
@@ -216,7 +224,11 @@ class StoryTest extends ValidatingTest {
           |
           |  entity Organization is { ??? } described as "nada"
           |
-          |  projection OrganizationViews is { fields { a: Integer} term xyz brief "y" } described as "nada"
+          |  projection OrganizationViews is {
+          |   record SimpleView { a: Integer}
+          |   term xyz
+          |   brief "y"
+          |  } described as "nada"
           |} described as "nada"
           |
           |application Improving_app is {

--- a/language/src/test/scala/com/reactific/riddl/language/TypeExpressionTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/TypeExpressionTest.scala
@@ -280,7 +280,7 @@ class TypeExpressionTest extends AnyWordSpec with Matchers {
     PathIdentifier(At.empty, Seq("a", "b", "c", "d", "entity"))
   )
 
-  val message = MessageType(At.empty, OtherKind, aggregation.fields)
+  val message = AggregateUseCaseTypeExpression(At.empty, OtherCase, aggregation.fields)
 
   val alias = AliasedTypeExpression(
     At.empty,
@@ -331,7 +331,7 @@ class TypeExpressionTest extends AnyWordSpec with Matchers {
     "Support Messages" in {
       AST.errorDescription(message) mustBe "Other of 27 fields"
       message.format mustBe
-        "other { integer: Integer, abstract: Abstract, " +
+        "Other { integer: Integer, abstract: Abstract, " +
         "bool: Boolean, current: Current, currency: Currency, date: Date, " +
         "dateTime: DateTime, decimal: Decimal, duration: Duration, " +
         "integer: Integer, length: Length, location: Location, " +

--- a/language/src/test/scala/com/reactific/riddl/language/TypeParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/TypeParserTest.scala
@@ -208,13 +208,13 @@ class TypeParserTest extends ParsingTest {
         val expected = Type(
           (1, 1, rip),
           Identifier((1, 6, rip), "mkt"),
-          MessageType(
+          AggregateUseCaseTypeExpression(
             (1, 12, rip),
             mk match {
-              case "command" => CommandKind
-              case "event"   => EventKind
-              case "query"   => QueryKind
-              case "result"  => ResultKind
+              case "command" => CommandCase
+              case "event"   => EventCase
+              case "query"   => QueryCase
+              case "result"  => ResultCase
             },
             Seq(
               Field(
@@ -329,9 +329,9 @@ class TypeParserTest extends ParsingTest {
       val expected = Type(
         (1, 1, rip),
         Identifier((1, 9, rip), "foo"),
-        MessageType(
+        AggregateUseCaseTypeExpression(
           (1, 16, rip),
-          CommandKind,
+          CommandCase,
           Seq(Field(
             (1, 18, rip),
             Identifier((1, 18, rip), "a"),

--- a/language/src/test/scala/com/reactific/riddl/language/UsageSpec.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/UsageSpec.scala
@@ -73,7 +73,7 @@ class UsageSpec extends AnyWordSpec with Matchers {
             val entityE = model.contents.head.contexts.head.entities.head
             val command = model.contents.head.contexts.head.types.head
             val fieldRef = command.typ match {
-              case x: MessageType => x.fields.find(_.id.value == "ref").get
+              case x: AggregateUseCaseTypeExpression => x.fields.find(_.id.value == "ref").get
               case _              => fail("Wrong kind of type expression")
             }
             result.uses(fieldRef).contains(entityE)

--- a/prettify/src/main/scala/com/reactific/riddl/prettify/RiddlFileEmitter.scala
+++ b/prettify/src/main/scala/com/reactific/riddl/prettify/RiddlFileEmitter.scala
@@ -185,8 +185,8 @@ case class RiddlFileEmitter(filePath: Path) extends TextFileWriter {
     this.add(line)
   }
 
-  def emitMessageType(mt: MessageType): RiddlFileEmitter = {
-    this.add(mt.messageKind.kind.toLowerCase).add(" ").emitFields(mt.fields)
+  def emitMessageType(mt: AggregateUseCaseTypeExpression): RiddlFileEmitter = {
+    this.add(mt.usecase.kind.toLowerCase).add(" ").emitFields(mt.fields)
   }
 
   def emitMessageRef(mr: MessageRef): RiddlFileEmitter = { this.add(mr.format) }
@@ -215,7 +215,7 @@ case class RiddlFileEmitter(filePath: Path) extends TextFileWriter {
       case ate: AggregateTypeExpression =>
         ate match {
           case aggr: Aggregation => emitAggregation(aggr)
-          case mt: MessageType      => emitMessageType(mt)
+          case mt: AggregateUseCaseTypeExpression      => emitMessageType(mt)
         }
       case p: PredefinedType => this.add(p.kind)
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 // This enables sbt-bloop to create bloop config files for Metals editors


### PR DESCRIPTION
Projections are now defined as a sequence of type definitions (including the new "Record" case) followed by handlers, includes, and terms. This change allows that structure to compile correctly. Validation of these changes has not been completed.