### PR TITLE
Implemented named on clause messages

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/ast/AbstractDefinitions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/AbstractDefinitions.scala
@@ -202,7 +202,7 @@ trait AbstractDefinitions {
 
     def hasTypes: Boolean = false
 
-    def find(name: String): Option[Definition] = {
+    def resolveNameTo(name: String): Option[Definition] = {
       contents.find(_.id.value == name)
     }
   }
@@ -222,10 +222,26 @@ trait AbstractDefinitions {
     *   The type of definition to which the references refers.
     */
   abstract class Reference[+T <: Definition: ClassTag] extends RiddlValue {
+    /**
+     * The Path identifier to the referenced definition
+     */
     def pathId: PathIdentifier
+
+    /**
+     * The optional identifier of the reference to be used locally in some other reference.
+     */
+    def id: Option[Identifier] = None
+
+    /**
+     * @return String
+     *         A string that describes this reference
+     */
     def identify: String = {
-      s"${classTag[T].runtimeClass.getSimpleName} '${pathId.format}'${loc.toShort}"
+      s"${classTag[T].runtimeClass.getSimpleName} ${
+        if (id.nonEmpty) {id.map(_.format + ": ")} else ""
+      }'${pathId.format}'${loc.toShort}"
     }
+
     override def isEmpty: Boolean = pathId.isEmpty
   }
 

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
@@ -332,46 +332,62 @@ trait Definitions extends Expressions with Options {
   }
 
   /** A Reference to a command message type
-    *
-    * @param loc
-    *   The location of the reference
-    * @param pathId
-    *   The path identifier to the event type
-    */
-  case class CommandRef(loc: At, pathId: PathIdentifier) extends MessageRef {
+   *
+   * @param loc
+   * The location of the reference
+   * @param pathId
+   * The path identifier to the event type
+   */
+  case class CommandRef(
+    loc: At,
+    override val id: Option[Identifier] = None,
+    pathId: PathIdentifier
+  ) extends MessageRef {
     def messageKind: AggregateUseCase = CommandCase
   }
 
   /** A Reference to an event message type
-    *
-    * @param loc
-    *   The location of the reference
-    * @param pathId
-    *   The path identifier to the event type
-    */
-  case class EventRef(loc: At, pathId: PathIdentifier) extends MessageRef {
+   *
+   * @param loc
+   * The location of the reference
+   * @param pathId
+   * The path identifier to the event type
+   */
+  case class EventRef(
+    loc: At,
+    override val id: Option[Identifier] = None,
+    pathId: PathIdentifier
+  ) extends MessageRef {
     def messageKind: AggregateUseCase = EventCase
   }
 
   /** A reference to a query message type
-    *
-    * @param loc
-    *   The location of the reference
-    * @param pathId
-    *   The path identifier to the query type
-    */
-  case class QueryRef(loc: At, pathId: PathIdentifier) extends MessageRef {
+   *
+   * @param loc
+   * The location of the reference
+   * @param pathId
+   * The path identifier to the query type
+   */
+  case class QueryRef(
+    loc: At,
+    override val id: Option[Identifier] = None,
+    pathId: PathIdentifier
+  ) extends MessageRef {
     def messageKind: AggregateUseCase = QueryCase
   }
 
   /** A reference to a result message type
-    *
-    * @param loc
-    *   The location of the reference
-    * @param pathId
-    *   The path identifier to the result type
-    */
-  case class ResultRef(loc: At, pathId: PathIdentifier) extends MessageRef {
+   *
+   * @param loc
+   * The location of the reference
+   * @param pathId
+   * The path identifier to the result type
+   */
+  case class ResultRef(
+    loc: At,
+    override val id: Option[Identifier] = None,
+    pathId: PathIdentifier
+  ) extends MessageRef {
     def messageKind: AggregateUseCase = ResultCase
   }
 
@@ -383,8 +399,9 @@ trait Definitions extends Expressions with Options {
     *   The path identifier to the result type
     */
   case class RecordRef(
-    loc: At = At.empty,
-    pathId: PathIdentifier = PathIdentifier.empty
+    loc: At,
+    override val id: Option[Identifier] = None,
+    pathId: PathIdentifier
   ) extends MessageRef {
     def messageKind: AggregateUseCase = RecordCase
     override def isEmpty: Boolean =
@@ -792,6 +809,10 @@ trait Definitions extends Expressions with Options {
     def format: String = ""
 
     final val kind: String = "OnMessageClause"
+
+    override def resolveNameTo(name: String): Option[Definition] = {
+      if (msg.id.nonEmpty && msg.id.get.value == name) Some(this) else None
+    }
   }
 
   /** Defines the actions to be taken when the component this OnClause occurs in

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ReferenceParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ReferenceParser.scala
@@ -19,28 +19,32 @@ private[parsing] trait ReferenceParser extends CommonParser {
       .map(tpl => (AdaptorRef.apply _).tupled(tpl))
   }
 
+  private def maybeName[u: P]: P[Option[Identifier]] = {
+    P((identifier ~ Punctuation.colon).?)
+  }
+
   private def commandRef[u: P]: P[CommandRef] = {
-    P(location ~ Keywords.command ~ pathIdentifier)
+    P(location ~ Keywords.command ~ maybeName ~ pathIdentifier)
       .map(tpl => (CommandRef.apply _).tupled(tpl))
   }
 
   private def eventRef[u: P]: P[EventRef] = {
-    P(location ~ Keywords.event ~ pathIdentifier)
+    P(location ~ Keywords.event ~ maybeName ~ pathIdentifier)
       .map(tpl => (EventRef.apply _).tupled(tpl))
   }
 
   private def queryRef[u: P]: P[QueryRef] = {
-    P(location ~ Keywords.query ~ pathIdentifier)
+    P(location ~ Keywords.query ~ maybeName ~ pathIdentifier)
       .map(tpl => (QueryRef.apply _).tupled(tpl))
   }
 
   private def resultRef[u: P]: P[ResultRef] = {
-    P(location ~ Keywords.result ~ pathIdentifier)
+    P(location ~ Keywords.result ~ maybeName ~ pathIdentifier)
       .map(tpl => (ResultRef.apply _).tupled(tpl))
   }
 
   private def recordRef[u: P]: P[RecordRef] = {
-    P(location ~ Keywords.record ~ pathIdentifier)
+    P(location ~ Keywords.record ~ maybeName ~ pathIdentifier)
       .map(tpl => (RecordRef.apply _).tupled(tpl))
   }
 

--- a/language/src/main/scala/com/reactific/riddl/language/passes/resolve/KindMap.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/passes/resolve/KindMap.scala
@@ -1,0 +1,29 @@
+package com.reactific.riddl.language.passes.resolve
+
+import com.reactific.riddl.language.AST.*
+
+import scala.collection.mutable
+import scala.reflect.{ClassTag, classTag}
+
+/** Unit Tests For KindMap */
+case class KindMap() {
+
+  private val map: mutable.HashMap[Class[_], Seq[Definition]] = mutable.HashMap.empty
+
+  def size: Int = map.size
+
+  def add(definition: Definition): Unit = {
+    val clazz = definition.getClass
+    val existing = map.getOrElse(clazz, Seq.empty)
+    map.update(clazz, existing :+ definition)
+  }
+
+  def definitionsOfKind[T <: Definition : ClassTag]: Seq[T] = {
+    val TClass = classTag[T].runtimeClass
+    map.getOrElse(TClass, Seq.empty[T]).map(_.asInstanceOf[T])
+  }
+}
+
+object KindMap {
+  val empty: KindMap = KindMap()
+}

--- a/language/src/main/scala/com/reactific/riddl/language/passes/resolve/ResolutionPass.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/passes/resolve/ResolutionPass.scala
@@ -12,6 +12,7 @@ import scala.reflect.{ClassTag, classTag}
 case class ResolutionOutput(
   messages: Messages.Messages,
   refMap: ReferenceMap,
+  kindMap: KindMap,
   usage: Usages,
 ) extends PassOutput
 
@@ -29,10 +30,11 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
   val commonOptions: CommonOptions = input.commonOptions
   val messages: Messages.Accumulator = Messages.Accumulator(input.commonOptions)
   val refMap: ReferenceMap = ReferenceMap(messages)
+  val kindMap: KindMap = KindMap()
   val symbols: SymbolsOutput = input.outputOf[SymbolsOutput]("symbols")
 
   override def result: ResolutionOutput =
-    ResolutionOutput(messages.toMessages, refMap, Usages(uses, usedBy))
+    ResolutionOutput(messages.toMessages, refMap, kindMap, Usages(uses, usedBy))
 
   override def close: Unit = ()
 
@@ -41,6 +43,7 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
   }
 
   def process(definition: Definition, parents: mutable.Stack[Definition]): Unit = {
+    kindMap.add(definition)
     val parentsAsSeq: Seq[Definition] = definition +: parents.toSeq
     definition match {
       case f: Field =>
@@ -129,7 +132,7 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
       case _: SagaStep => () // no references
       case _: SequentialInteractions => () // no references
       case _: Term => () // no references
-      // case _ => () // NOTE: Never have this catchall
+      // case _ => () // NOTE: Never have this catchall! Want compile time errors.
     }
   }
 
@@ -216,8 +219,10 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
 
   private def resolveExpr(expr: Expression, parents: Seq[Definition]): Unit = {
     expr match {
-      case ValueOperator(_, path) => resolveAPathId[Field](path, parents)
-      case ValueCondition(_, path) => resolveAPathId[Field](path, parents)
+      case ValueOperator(_, path) =>
+        resolveAPathId[Field](path, parents)
+      case ValueCondition(_, path) =>
+        resolveAPathId[Field](path, parents)
       case AggregateConstructionExpression(_, msg, _) => resolveAPathId[Type](msg, parents)
       case NewEntityIdOperator(_, entityId) => resolveAPathId[Entity](entityId, parents)
       case FunctionCallExpression(_, func, args) =>
@@ -286,11 +291,11 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
 
       // Define a function to identify the starting point in the parents
       def startingPoint(defn: Definition): Boolean = {
-        defn.id.value == topName || defn.contents.exists(_.id.value == topName)
+        defn.id.value == topName || defn.resolveNameTo(topName).nonEmpty
       }
 
       // Drop parents until starting point found
-      val newParents = parents.dropUntil(startingPoint(_))
+      val newParents = parents.dropUntil(startingPoint)
 
       // If we dropped all the parents then the path isn't valid
       if (newParents.isEmpty) {
@@ -299,8 +304,7 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
       } else {
         // we found the starting point, and adjusted the parent stack correspondingly
         // use resolveRelativePath to descend through names
-        val pid = PathIdentifier(pathId.loc, pathId.value)
-        resolveRelativePath(pid, newParents)
+        resolveRelativePath(pathId, newParents)
       }
     }
 
@@ -483,7 +487,7 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
           // its fields so we need to push that typeRef's name on the name stack.
           adjustStacksForPid[Type](st.typ.pathId, parentStack)
         case oc: OnMessageClause =>
-          // if we're at an onClause that references a message then we
+          // if we're at an onClause that references a named message then we
           // need to push that message's path on the name stack
           adjustStacksForPid[Type](oc.msg.pathId, parentStack)
         case f: Field =>
@@ -505,7 +509,12 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
     }
   }
 
-  // final val maxTraversal = 10
+  private def findResolution(soughtName: String, candidate: Definition): Boolean = {
+    candidate match {
+      case omc: OnMessageClause if omc.msg.id.nonEmpty => omc.msg.id.get.value == soughtName
+      case other: Definition => other.id.value == soughtName
+    }
+  }
 
   /** Resolve a Relative PathIdentifier. If the path is already resolved or it
    * has no empty components then we can resolve it from the map or the
@@ -571,7 +580,7 @@ case class ResolutionPass(input: PassInput) extends Pass(input) with
           val candidates = findCandidates(parentStack)
 
           // Now find the match, if any, and handle appropriately
-          val found = candidates.find(_.id.value == soughtName)
+          val found = candidates.find(candidate => findResolution(soughtName, candidate))
           found match {
             case Some(q: Definition) =>
               // found the named item, and it is a Container, so put it on

--- a/language/src/main/scala/com/reactific/riddl/language/passes/validate/BasicValidation.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/passes/validate/BasicValidation.scala
@@ -16,7 +16,6 @@ trait BasicValidation {
 
   def symbols: SymbolsOutput
   def resolution: ResolutionOutput
-
   def messages: Messages.Accumulator
 
   def parentOf(definition: Definition): Container[Definition] = {

--- a/language/src/main/scala/com/reactific/riddl/language/passes/validate/StreamingValidation.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/passes/validate/StreamingValidation.scala
@@ -3,40 +3,9 @@ package com.reactific.riddl.language.passes.validate
 import com.reactific.riddl.language.AST.*
 import com.reactific.riddl.language.Messages
 import com.reactific.riddl.language.ast.At
-import com.reactific.riddl.language.passes.PassInput
-import com.reactific.riddl.language.passes.symbols.SymbolsOutput
 
 trait StreamingValidation extends ExampleValidation {
 
-  def input: PassInput
-  def symbols: SymbolsOutput
-  protected var inlets: Seq[Inlet] = Seq.empty[Inlet]
-
-  def addInlet(in: Inlet): this.type = {
-    inlets = inlets :+ in
-    this
-  }
-
-  protected var outlets: Seq[Outlet] = Seq.empty[Outlet]
-
-  def addOutlet(out: Outlet): this.type = {
-    outlets = outlets :+ out
-    this
-  }
-
-  protected var connectors: Seq[Connector] = Seq.empty[Connector]
-
-  def addConnector(conn: Connector): this.type = {
-    connectors = connectors :+ conn
-    this
-  }
-
-  protected var streamlets: Seq[Streamlet] = Seq.empty[Streamlet]
-
-  def addStreamlet(proc: Streamlet): this.type = {
-    streamlets = streamlets :+ proc
-    this
-  }
 
   def checkStreaming(root: RootContainer): Unit = {
     val start = root.domains.headOption.map(_.id.loc).getOrElse(At.empty)
@@ -45,6 +14,11 @@ trait StreamingValidation extends ExampleValidation {
     checkUnattachedOutlets()
     checkUnusedOutlets()
   }
+
+  val inlets: Seq[Inlet] = resolution.kindMap.definitionsOfKind[Inlet]
+  val outlets: Seq[Outlet] = resolution.kindMap.definitionsOfKind[Outlet]
+  val streamlets: Seq[Streamlet] = resolution.kindMap.definitionsOfKind[Streamlet]
+  val connectors: Seq[Connector] = resolution.kindMap.definitionsOfKind[Connector]
 
   private def checkStreamingUsage(loc: At): Unit = {
     if (inlets.isEmpty && outlets.isEmpty && streamlets.isEmpty) {

--- a/language/src/main/scala/com/reactific/riddl/language/passes/validate/ValidationPass.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/passes/validate/ValidationPass.scala
@@ -24,10 +24,10 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
   requires(ResolutionPass)
 
   override def name: String = ValidationPass.name
-  val resolution: ResolutionOutput = input.outputOf[ResolutionOutput](ResolutionPass.name)
-  val symbols: SymbolsOutput = input.outputOf[SymbolsOutput](SymbolsPass.name)
 
-  val messages: Messages.Accumulator = Messages.Accumulator(input.commonOptions)
+  lazy val resolution: ResolutionOutput = input.outputOf[ResolutionOutput](ResolutionPass.name)
+  lazy val symbols: SymbolsOutput = input.outputOf[SymbolsOutput](SymbolsPass.name)
+  lazy val messages: Messages.Accumulator = Messages.Accumulator(input.commonOptions)
 
   /**
    * Generate the output of this Pass. This will only be called after all the calls
@@ -36,8 +36,8 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
    * @return an instance of the output type
    */
   override def result: ValidationOutput = {
-      ValidationOutput(messages.toMessages, inlets, outlets,
-        connectors, streamlets, sends.toMap)
+    ValidationOutput(messages.toMessages, inlets, outlets,
+      connectors, streamlets, sends.toMap)
   }
 
   def postProcess(root: RootContainer): Unit = {
@@ -193,7 +193,6 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
     inlet: Inlet,
     parents: Seq[Definition]
   ): Unit = {
-    addInlet(inlet)
     checkDefinition(parents, inlet)
     checkRef[Type](inlet.type_, inlet, parents)
   }
@@ -202,7 +201,6 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
     outlet: Outlet,
     parents: Seq[Definition]
   ): Unit = {
-    addOutlet(outlet)
     checkDefinition(parents, outlet)
     checkRef[Type](outlet.type_, outlet, parents)
   }
@@ -211,7 +209,6 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
     connector: Connector,
     parents: Seq[Definition]
   ): Unit = {
-    addConnector(connector)
     val refParents = connector +: parents
     val maybeOutlet = checkMaybeRef[Outlet](connector.from, connector, refParents)
     val maybeInlet = checkMaybeRef[Inlet](connector.to, connector, refParents)
@@ -417,7 +414,6 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
     s: Streamlet,
     parents: Seq[Definition]
   ): Unit = {
-    addStreamlet(s)
     checkContainer(parents, s)
     checkStreamletShape(s)
     checkDescription(s)

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/CommonParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/CommonParserTest.scala
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
 import com.reactific.riddl.language.AST.*
+import com.reactific.riddl.language.ParsingTest
 import com.reactific.riddl.language.ast.At
 
 /** Unit Tests For CommonParser */

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/ConditionParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/ConditionParserTest.scala
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
 import com.reactific.riddl.language.AST.*
 import com.reactific.riddl.language.ast.At
-import com.reactific.riddl.language.parsing.RiddlParserInput
+import com.reactific.riddl.language.{AST, ParsingTest}
 import org.scalatest.Assertion
 
 import scala.collection.immutable.ListMap

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/ExpressionParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/ExpressionParserTest.scala
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
 import com.reactific.riddl.language.AST.*
+import com.reactific.riddl.language.ParsingTest
 import com.reactific.riddl.language.ast.At
 import org.scalatest.Assertion
 

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/ParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/ParserTest.scala
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
 import com.reactific.riddl.language.AST.*
-import com.reactific.riddl.language.parsing.RiddlParserInput
+import com.reactific.riddl.language.{ParsingTest, TestParser}
 
 /** Unit Tests For ParserTest */
 class ParserTest extends ParsingTest {

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/StreamingParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/StreamingParserTest.scala
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
 import com.reactific.riddl.language.AST.*
-import com.reactific.riddl.language.parsing.RiddlParserInput
+import com.reactific.riddl.language.{AST, ParsingTest}
 
 /** Unit Tests For StreamingParser */
 class StreamingParserTest extends ParsingTest {

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/TopLevelParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/TopLevelParserTest.scala
@@ -4,15 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
 import com.reactific.riddl.language.AST.*
 import com.reactific.riddl.language.ast.At
-import com.reactific.riddl.language.parsing.{
-  RiddlParserInput,
-  StringParserInput,
-  TopLevelParser
-}
+import com.reactific.riddl.language.{AST, ParsingTestBase}
 
 import java.io.File
 import scala.io.Source

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/TypeParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/TypeParserTest.scala
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.reactific.riddl.language
+package com.reactific.riddl.language.parsing
 
-import com.reactific.riddl.language.AST.Field
-import com.reactific.riddl.language.AST.*
-import com.reactific.riddl.language.parsing.RiddlParserInput
+import com.reactific.riddl.language.AST.{Field, *}
+import com.reactific.riddl.language.ParsingTest
 
 /** Unit Tests For TypesParserTest */
 class TypeParserTest extends ParsingTest {

--- a/language/src/test/scala/com/reactific/riddl/language/passes/validate/HandlerValidatorTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/passes/validate/HandlerValidatorTest.scala
@@ -96,29 +96,29 @@ class HandlerValidatorTest extends ValidatingTest {
           assertValidationMessage(
             msgs,
             Error,
-            "Type 'Incoming'(8:10) should reference an Event but is " +
-              "a String type instead"
+            "Type 'Incoming'(8:10) should reference an Event but is a String type instead"
           )
       }
     }
 
     "produce an error when on clause references a state field that does not exist" in {
-      val input = """
-                    |domain entityTest is {
-                    |context EntityContext is {
-                    |entity Hamburger is {
-                    |  record Fields is { field1: Number }
-                    |  state HamburgerState of Fields = {
-                    |    handler foo is {
-                    |      on command EntityCommand { example only {
-                    |        then set nonExistingField to 123
-                    |      } }
-                    |    }
-                    |  }
-                    |}
-                    |}
-                    |}
-                    |""".stripMargin
+      val input =
+        """
+          |domain entityTest is {
+          |context EntityContext is {
+          |entity Hamburger is {
+          |  record Fields is { field1: Number }
+          |  state HamburgerState of Fields = {
+          |    handler foo is {
+          |      on command EntityCommand { example only {
+          |        then set nonExistingField to 123
+          |      } }
+          |    }
+          |  }
+          |}
+          |}
+          |}
+          |""".stripMargin
       parseAndValidateDomain(input, CommonOptions.noMinorWarnings, shouldFailOnErrors = false) {
         case (_, _, msgs: Messages) =>
           assertValidationMessage(
@@ -133,22 +133,22 @@ class HandlerValidatorTest extends ValidatingTest {
     "produce an error when on clause sets state from a message field that does not exist" in {
       val input =
         """
-           |domain entityTest is {
-           |context EntityContext is {
-           |entity Hamburger is {
-           |  type EntityCommand is command { foo: Number }
-           |  record Fields is {  field1: Number  }
-           |  state HamburgerState of Fields = {
-           |    handler foo is {
-           |      on command EntityCommand { example only {
-           |        then set field1 to @bar
-           |      } }
-           |    }
-           |  }
-           |}
-           |}
-           |}
-           |""".stripMargin
+          |domain entityTest is {
+          |context EntityContext is {
+          |entity Hamburger is {
+          |  type EntityCommand is command { foo: Number }
+          |  record Fields is {  field1: Number  }
+          |  state HamburgerState of Fields = {
+          |    handler foo is {
+          |      on command EntityCommand { example only {
+          |        then set field1 to @bar
+          |      } }
+          |    }
+          |  }
+          |}
+          |}
+          |}
+          |""".stripMargin
       parseAndValidateDomain(input, CommonOptions.noMinorWarnings, shouldFailOnErrors = false) {
         case (_, _, msgs: Messages) =>
           assertValidationMessage(
@@ -160,23 +160,24 @@ class HandlerValidatorTest extends ValidatingTest {
     }
 
     "produce an error when on clause sets state from incompatible type of message field" in {
-      val input = """
-                    |domain entityTest is {
-                    |context EntityContext is {
-                    |entity Hamburger is {
-                    |  type EntityCommand is command { foo: String }
-                    |  record Fields is { field1: Number }
-                    |  state HamburgerState of Fields = {
-                    |    handler doit is {
-                    |      on command EntityCommand { example only {
-                    |        then set field1 to @foo
-                    |      } }
-                    |    }
-                    |  }
-                    |}
-                    |}
-                    |}
-                    |""".stripMargin
+      val input =
+        """
+          |domain entityTest is {
+          |context EntityContext is {
+          |entity Hamburger is {
+          |  type EntityCommand is command { foo: String }
+          |  record Fields is { field1: Number }
+          |  state HamburgerState of Fields = {
+          |    handler doit is {
+          |      on command EntityCommand { example only {
+          |        then set field1 to @foo
+          |      } }
+          |    }
+          |  }
+          |}
+          |}
+          |}
+          |""".stripMargin
       parseAndValidateDomain(input, CommonOptions.noMinorWarnings, shouldFailOnErrors = false) {
         case (_, _, msgs: Messages) =>
           assertValidationMessage(
@@ -184,6 +185,29 @@ class HandlerValidatorTest extends ValidatingTest {
             Error,
             "assignment compatibility, but field:\n  field1"
           )
+      }
+    }
+    "allow message clauses to name the message and it resolves" in {
+      val input =
+        """domain entityTest is {
+          |context EntityContext is {
+          |entity Hamburger is {
+          |  type EntityCommand is command { foo: String }
+          |  record Fields is { field1: String }
+          |  state HamburgerState of Fields = {
+          |    handler doit is {
+          |      on command ec:EntityCommand { example only {
+          |        then set Fields.field1 to @ec.foo
+          |      } }
+          |    }
+          |  }
+          |}
+          |}
+          |}
+          |""".stripMargin
+      parseAndValidateDomain(input, CommonOptions.noMinorWarnings, shouldFailOnErrors = false) {
+        case (_, _, msgs: Messages) =>
+          msgs.justErrors.format mustBe (empty)
       }
     }
   }


### PR DESCRIPTION
It is more accurate to name and reference the message an On Clause is processing than to refer to its type. Allow this syntax:

`on event t:Type { ... }`

Actions can then refer to "t" as a local field to extract data from the provided message