### PR TITLE
fix: Allow function definitions in more places

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
@@ -650,11 +650,16 @@ trait Definitions extends Expressions with Options {
     brief: Option[LiteralString] = Option.empty[LiteralString],
     description: Option[Description] = None
   ) extends VitalDefinition[FunctionOption, FunctionDefinition]
-      with WithTypes
-      with SagaDefinition
-      with EntityDefinition
-      with ContextDefinition
-      with FunctionDefinition {
+    with WithTypes
+    with AdaptorDefinition
+    with ApplicationDefinition
+    with ContextDefinition
+    with EntityDefinition
+    with FunctionDefinition
+    with ProjectorDefinition
+    with RepositoryDefinition
+    with SagaDefinition
+    with StreamletDefinition {
     override lazy val contents: Seq[FunctionDefinition] = {
       super.contents ++ input.map(_.fields).getOrElse(Seq.empty[Field]) ++
         output.map(_.fields).getOrElse(Seq.empty[Field]) ++ types ++
@@ -1059,6 +1064,7 @@ trait Definitions extends Expressions with Options {
     outlets: Seq[Outlet] = Seq.empty[Outlet],
     types: Seq[Type] = Seq.empty[Type],
     constants: Seq[Constant] = Seq.empty[Constant],
+    functions: Seq[Function] = Seq.empty[Function],
     includes: Seq[Include[AdaptorDefinition]] = Seq
       .empty[Include[AdaptorDefinition]],
     authors: Seq[AuthorRef] = Seq.empty[AuthorRef],
@@ -1127,6 +1133,7 @@ trait Definitions extends Expressions with Options {
     inlets: Seq[Inlet] = Seq.empty[Inlet],
     outlets: Seq[Outlet] = Seq.empty[Outlet],
     authors: Seq[AuthorRef] = Seq.empty[AuthorRef],
+    functions: Seq[Function] = Seq.empty[Function],
     includes: Seq[Include[RepositoryDefinition]] = Seq
       .empty[Include[RepositoryDefinition]],
     options: Seq[RepositoryOption] = Seq.empty[RepositoryOption],
@@ -1195,6 +1202,7 @@ trait Definitions extends Expressions with Options {
     inlets: Seq[Inlet] = Seq.empty[Inlet],
     outlets: Seq[Outlet] = Seq.empty[Outlet],
     handlers: Seq[Handler] = Seq.empty[Handler],
+    functions: Seq[Function] = Seq.empty[Function],
     invariants: Seq[Invariant] = Seq.empty[Invariant],
     terms: Seq[Term] = Seq.empty[Term],
     brief: Option[LiteralString] = Option.empty[LiteralString],
@@ -1470,6 +1478,7 @@ trait Definitions extends Expressions with Options {
     inlets: Seq[Inlet] = Seq.empty[Inlet],
     outlets: Seq[Outlet] = Seq.empty[Outlet],
     handlers: Seq[Handler] = Seq.empty[Handler],
+    functions: Seq[Function] = Seq.empty[Function],
     types: Seq[Type] = Seq.empty[Type],
     includes: Seq[Include[StreamletDefinition]] = Seq
       .empty[Include[StreamletDefinition]],
@@ -2168,6 +2177,7 @@ trait Definitions extends Expressions with Options {
     handlers: Seq[Handler] = Seq.empty[Handler],
     inlets: Seq[Inlet] = Seq.empty[Inlet],
     outlets: Seq[Outlet] = Seq.empty[Outlet],
+    functions: Seq[Function] = Seq.empty[Function],
     authors: Seq[AuthorRef] = Seq.empty[AuthorRef],
     terms: Seq[Term] = Seq.empty[Term],
     includes: Seq[Include[ApplicationDefinition]] = Seq.empty,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/AdaptorParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/AdaptorParser.scala
@@ -15,9 +15,10 @@ import fastparse.ScalaWhitespace.*
 /** Parser rules for Adaptors */
 private[parsing] trait AdaptorParser
     extends HandlerParser
-    with GherkinParser
-    with ActionParser
-    with StreamingParser {
+      with GherkinParser
+      with ActionParser
+      with FunctionParser
+      with StreamingParser {
 
   private def adaptorOptions[u: P]: P[Seq[AdaptorOption]] = {
     options[u, AdaptorOption](StringIn(Options.technology).!) {
@@ -32,7 +33,7 @@ private[parsing] trait AdaptorParser
 
   private def adaptorDefinitions[u: P]: P[Seq[AdaptorDefinition]] = {
     P(
-      (handler | inlet | outlet | adaptorInclude | term | constant).rep(1) |
+      (handler | function | inlet | outlet | adaptorInclude | term | constant).rep(1) |
         undefined(Seq.empty[AdaptorDefinition])
     )
   }
@@ -77,6 +78,7 @@ private[parsing] trait AdaptorParser
         val inlets = mapTo[Inlet](groups.get(classOf[Inlet]))
         val outlets = mapTo[Outlet](groups.get(classOf[Outlet]))
         val types = mapTo[Type](groups.get(classOf[Outlet]))
+        val functions = mapTo[Function](groups.get(classOf[Function]))
         val constants = mapTo[Constant](groups.get(classOf[Constant]))
         Adaptor(
           loc,
@@ -88,6 +90,7 @@ private[parsing] trait AdaptorParser
           outlets,
           types,
           constants,
+          functions,
           includes,
           authorRefs,
           options,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ApplicationParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ApplicationParser.scala
@@ -13,10 +13,11 @@ import fastparse.ScalaWhitespace.*
 
 private[parsing] trait ApplicationParser
     extends CommonParser
-    with ReferenceParser
-    with StreamingParser
-    with HandlerParser
-    with TypeParser {
+      with ReferenceParser
+      with StreamingParser
+      with FunctionParser
+      with HandlerParser
+      with TypeParser {
 
   private def applicationOptions[u: P]: P[Seq[ApplicationOption]] = {
     options[u, ApplicationOption](StringIn(Options.technology).!) {
@@ -55,7 +56,7 @@ private[parsing] trait ApplicationParser
 
   private def applicationDefinition[u: P]: P[ApplicationDefinition] = {
     P(
-      group | handler | inlet | outlet | term | typeDef |
+      group | handler | function | inlet | outlet | term | typeDef |
         constant | applicationInclude
     )
   }
@@ -85,6 +86,7 @@ private[parsing] trait ApplicationParser
       val constants = mapTo[Constant](groups.get(classOf[Constant]))
       val grps = mapTo[Group](groups.get(classOf[Group]))
       val handlers = mapTo[Handler](groups.get(classOf[Group]))
+      val functions = mapTo[Function](groups.get(classOf[Function]))
       val inlets = mapTo[Inlet](groups.get(classOf[Inlet]))
       val outlets = mapTo[Outlet](groups.get(classOf[Outlet]))
       val terms = mapTo[Term](groups.get(classOf[Term]))
@@ -104,6 +106,7 @@ private[parsing] trait ApplicationParser
         handlers,
         inlets,
         outlets,
+        functions,
         authorRefs,
         terms,
         includes,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ExpressionParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ExpressionParser.scala
@@ -187,8 +187,8 @@ private[parsing] trait ExpressionParser
     P(
       location ~
         (Operators.plus.! | Operators.minus.! | Operators.times.! |
-          Operators.div.! | Operators.mod.!) ~ Punctuation.roundOpen ~
-        expression.rep(0, Punctuation.comma) ~ Punctuation.roundClose
+          Operators.div.! | Operators.mod.!) ~ Punctuation.roundOpen./ ~
+        expression.rep(0, Punctuation.comma) ~ Punctuation.roundClose./
     ).map { tpl => (ArithmeticOperator.apply _).tupled(tpl) }
   }
 

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ProjectorParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ProjectorParser.scala
@@ -14,8 +14,9 @@ import Terminals.*
 /** Unit Tests For FunctionParser */
 private[parsing] trait ProjectorParser
     extends TypeParser
-    with HandlerParser
-    with StreamingParser {
+      with HandlerParser
+      with FunctionParser
+      with StreamingParser {
 
   private def projectionOptions[u: P]: P[Seq[ProjectorOption]] = {
     options[u, ProjectorOption](StringIn(Options.technology).!) {
@@ -31,7 +32,7 @@ private[parsing] trait ProjectorParser
 
   private def projectionDefinitions[u: P]: P[Seq[ProjectorDefinition]] = {
     P(
-      term | projectionInclude | handler | inlet | outlet | invariant |
+      term | projectionInclude | handler | function | inlet | outlet | invariant |
         constant | typeDef
     ).rep(0)
   }
@@ -75,6 +76,7 @@ private[parsing] trait ProjectorParser
           ) =>
         val groups = definitions.groupBy(_.getClass)
         val handlers = mapTo[Handler](groups.get(classOf[Handler]))
+        val functions = mapTo[Function](groups.get(classOf[Function]))
         val constants = mapTo[Constant](groups.get(classOf[Constant]))
         val inlets = mapTo[Inlet](groups.get(classOf[Inlet]))
         val outlets = mapTo[Outlet](groups.get(classOf[Outlet]))
@@ -96,6 +98,7 @@ private[parsing] trait ProjectorParser
           inlets,
           outlets,
           handlers,
+          functions,
           invariants,
           terms,
           briefly,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/RepositoryParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/RepositoryParser.scala
@@ -12,7 +12,7 @@ import fastparse.*
 import fastparse.ScalaWhitespace.*
 import Terminals.*
 
-private[parsing] trait RepositoryParser extends HandlerParser with StreamingParser {
+private[parsing] trait RepositoryParser extends HandlerParser with StreamingParser with FunctionParser {
 
   private def repositoryOptions[u: P]: P[Seq[RepositoryOption]] = {
     options[u, RepositoryOption](StringIn(Options.technology).!) {
@@ -27,7 +27,7 @@ private[parsing] trait RepositoryParser extends HandlerParser with StreamingPars
   }
 
   private def repositoryDefinitions[u: P]: P[Seq[RepositoryDefinition]] = {
-    P(typeDef | handler | term | repositoryInclude | inlet | outlet ).rep(0)
+    P(typeDef | handler | function | term | repositoryInclude | inlet | outlet).rep(0)
   }
 
   def repository[u: P]: P[Repository] = {
@@ -40,6 +40,7 @@ private[parsing] trait RepositoryParser extends HandlerParser with StreamingPars
       val groups = defs.groupBy(_.getClass)
       val types = mapTo[Type](groups.get(classOf[Type]))
       val handlers = mapTo[Handler](groups.get(classOf[Handler]))
+      val functions = mapTo[Function](groups.get(classOf[Function]))
       val inlets = mapTo[Inlet](groups.get(classOf[Inlet]))
       val outlets = mapTo[Outlet](groups.get(classOf[Outlet]))
       val terms = mapTo[Term](groups.get(classOf[Term]))
@@ -55,6 +56,7 @@ private[parsing] trait RepositoryParser extends HandlerParser with StreamingPars
         inlets,
         outlets,
         authors,
+        functions,
         includes,
         opts,
         terms,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/StreamingParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/StreamingParser.scala
@@ -136,6 +136,7 @@ private[parsing] trait StreamingParser
       val inlets = mapTo[Inlet](groups.get(classOf[Inlet]))
       val outlets = mapTo[Outlet](groups.get(classOf[Outlet]))
       val handlers = mapTo[Handler](groups.get(classOf[Handler]))
+      val functions = mapTo[Function](groups.get(classOf[Function]))
       val types = mapTo[Type](groups.get(classOf[Type]))
       val terms = mapTo[Term](groups.get(classOf[Term]))
       val includes = mapTo[Include[StreamletDefinition]](
@@ -150,6 +151,7 @@ private[parsing] trait StreamingParser
         inlets,
         outlets,
         handlers,
+        functions,
         types,
         includes,
         auths,

--- a/language/src/test/scala/com/reactific/riddl/language/ParsingTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/ParsingTest.scala
@@ -47,6 +47,8 @@ case class TestParser(input: RiddlParserInput, throwOnError: Boolean = false)
       case x if x == classOf[AST.Streamlet] => streamlet(_)
       case x if x == classOf[AST.Saga]      => saga(_)
       case x if x == classOf[AST.Example]   => example(_)
+      case x if x == classOf[AST.Saga]      => repository(_)
+      case x if x == classOf[AST.Saga]      => projector(_)
       case x if x == classOf[AST.Epic]      => epic(_)
       case _ =>
         throw new RuntimeException(

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/StreamingParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/StreamingParserTest.scala
@@ -38,6 +38,7 @@ class StreamingParserTest extends ParsingTest {
         )
       ),
       List.empty[Handler],
+      List.empty[Function],
       List.empty[Type],
       Seq.empty[Include[StreamletDefinition]],
       Seq.empty[AuthorRef],
@@ -136,6 +137,7 @@ class StreamingParserTest extends ParsingTest {
               )
             ),
             List.empty[Handler],
+            List.empty[Function],
             List.empty[Type],
             Seq.empty[Include[StreamletDefinition]],
             Seq.empty[AuthorRef],
@@ -179,6 +181,7 @@ class StreamingParserTest extends ParsingTest {
               )
             ),
             List.empty[Handler],
+            List.empty[Function],
             List.empty[Type],
             Seq.empty[Include[StreamletDefinition]],
             Seq.empty[AuthorRef],
@@ -213,6 +216,7 @@ class StreamingParserTest extends ParsingTest {
             ),
             List.empty[Outlet],
             List.empty[Handler],
+            List.empty[Function],
             List.empty[Type],
             Seq.empty[Include[StreamletDefinition]],
             Seq.empty[AuthorRef],

--- a/language/src/test/scala/com/reactific/riddl/language/passes/validate/ContextValidationTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/passes/validate/ContextValidationTest.scala
@@ -192,6 +192,7 @@ class ContextValidationTest extends ValidatingTest {
               ),
               List(),
               List(),
+              List(),
               None,
               None
             )

--- a/language/src/test/scala/com/reactific/riddl/language/passes/validate/FunctionValidatorTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/passes/validate/FunctionValidatorTest.scala
@@ -45,6 +45,23 @@ class FunctionValidatorTest extends ValidatingTest {
         )
       }
     }
+    "validate simple function" in {
+      val input =
+        """function percent {
+        |  requires { number: Number }
+        |  returns { result: Number }
+        |  example calc is {
+        |    then set percent.result to /(@percent.number , 100.0)
+        |  }
+        |}
+        |""".stripMargin
+      parseAndValidateInContext[Function](input, shouldFailOnErrors = true) { case (function, _, msgs) =>
+        function.id.value mustBe "percent"
+        function.examples mustNot be(empty)
+        msgs.justErrors must be(empty)
+      }
+
+    }
     "validate function examples" in {
       val input = """
                     |  function AnAspect is {
@@ -61,7 +78,7 @@ class FunctionValidatorTest extends ValidatingTest {
                     |  } described as "foo"
                     |""".stripMargin
 
-      parseAndValidateInContext[Function](input, shouldFailOnErrors=false) { case (function, _, msgs) =>
+      parseAndValidateInContext[Function](input, shouldFailOnErrors = false) { case (function, _, msgs) =>
         function.id.value mustBe "AnAspect"
         function.examples mustNot be(empty)
         msgs mustNot be(empty)


### PR DESCRIPTION
It was always the intention to allow functions wherever a handler definition could occur. Unfortunately, they were omitted from Adaptors, Applications, Projections, Repositories, and Streamlets. This patch rectifies that situation.