### PR TITLE
Workaround for scalac bug preventing scaladoc gen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,6 @@ lazy val language: Project = project
     name := "riddl-language",
     // FIXME: Don't defeat doc generation
     //     See https://github.com/lampepfl/dotty/issues/17577 for details
-    Compile / sbt.Keys.doc / sources := Seq(),
     coverageExcludedPackages := "<empty>;.*BuildInfo;.*Terminals",
     libraryDependencies ++= Seq(Dep.fastparse, Dep.lang3, Dep.commons_io) ++
       Dep.testing

--- a/language/src/main/scala/com/reactific/riddl/language/AST.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/AST.scala
@@ -6,15 +6,14 @@
 
 package com.reactific.riddl.language
 
-/** Abstract Syntax Tree This object defines the model for processing RIDDL and
-  * producing a raw AST from it. This raw AST has no referential integrity, it
-  * just results from applying the parsing rules to the input. The RawAST models
-  * produced from parsing are syntactically correct but have no semantic
-  * validation. The Transformation passes convert RawAST model to AST model
-  * which is referentially and semantically consistent (or the user gets an
-  * error).
+import com.reactific.riddl.language.ast._
+
+/** Abstract Syntax Tree This object defines the model for processing RIDDL and producing a raw AST from it. This raw
+  * AST has no referential integrity, it just results from applying the parsing rules to the input. The RawAST models
+  * produced from parsing are syntactically correct but have no semantic validation. The Transformation passes convert
+  * RawAST model to AST model which is referentially and semantically consistent (or the user gets an error).
   */
-object AST extends ast.Actions  {
+object AST extends AbstractDefinitions with Actions with Definitions with Expressions with Options with Types {
 
   def findAuthors(
     defn: Definition,
@@ -22,13 +21,12 @@ object AST extends ast.Actions  {
   ): Seq[AuthorRef] = {
     if defn.hasAuthors then {
       defn.asInstanceOf[WithAuthors].authors
-    }
-    else {
-      parents.find(d =>
-        d.isInstanceOf[WithAuthors] && d.asInstanceOf[WithAuthors].hasAuthors
-      ).map(_.asInstanceOf[WithAuthors].authors).getOrElse(Seq.empty[AuthorRef])
+    } else {
+      parents
+        .find(d => d.isInstanceOf[WithAuthors] && d.asInstanceOf[WithAuthors].hasAuthors)
+        .map(_.asInstanceOf[WithAuthors].authors)
+        .getOrElse(Seq.empty[AuthorRef])
     }
   }
-
 
 }

--- a/language/src/main/scala/com/reactific/riddl/language/AST.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/AST.scala
@@ -6,14 +6,15 @@
 
 package com.reactific.riddl.language
 
-import com.reactific.riddl.language.ast._
-
-/** Abstract Syntax Tree This object defines the model for processing RIDDL and producing a raw AST from it. This raw
-  * AST has no referential integrity, it just results from applying the parsing rules to the input. The RawAST models
-  * produced from parsing are syntactically correct but have no semantic validation. The Transformation passes convert
-  * RawAST model to AST model which is referentially and semantically consistent (or the user gets an error).
+/** Abstract Syntax Tree This object defines the model for processing RIDDL and
+  * producing a raw AST from it. This raw AST has no referential integrity, it
+  * just results from applying the parsing rules to the input. The RawAST models
+  * produced from parsing are syntactically correct but have no semantic
+  * validation. The Transformation passes convert RawAST model to AST model
+  * which is referentially and semantically consistent (or the user gets an
+  * error).
   */
-object AST extends AbstractDefinitions with Actions with Definitions with Expressions with Options with Types {
+object AST extends ast.AbstractDefinitions with ast.Actions with ast.Definitions with ast.Expressions with ast.Options with ast.Types {
 
   def findAuthors(
     defn: Definition,
@@ -21,12 +22,13 @@ object AST extends AbstractDefinitions with Actions with Definitions with Expres
   ): Seq[AuthorRef] = {
     if defn.hasAuthors then {
       defn.asInstanceOf[WithAuthors].authors
-    } else {
-      parents
-        .find(d => d.isInstanceOf[WithAuthors] && d.asInstanceOf[WithAuthors].hasAuthors)
-        .map(_.asInstanceOf[WithAuthors].authors)
-        .getOrElse(Seq.empty[AuthorRef])
+    }
+    else {
+      parents.find(d =>
+        d.isInstanceOf[WithAuthors] && d.asInstanceOf[WithAuthors].hasAuthors
+      ).map(_.asInstanceOf[WithAuthors].authors).getOrElse(Seq.empty[AuthorRef])
     }
   }
+
 
 }

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Actions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Actions.scala
@@ -6,8 +6,8 @@
 
 package com.reactific.riddl.language.ast
 
-/** This trait defines all the Actions that can be invoked from an Example and classified by the kind of definition to
-  * which they are applicable
+/** This trait defines all the Actions that can be invoked from an Example and
+  * classified by the kind of definition to which they are applicable
   */
 trait Actions {
   this: Definitions with Expressions with Types with Options with AbstractDefinitions =>
@@ -21,8 +21,8 @@ trait Actions {
   sealed trait SagaAction extends Action
   sealed trait AnyAction extends Action
 
-  /** An action whose behavior is specified as a text string allowing extension to arbitrary actions not otherwise
-    * handled by RIDDL's syntax.
+  /** An action whose behavior is specified as a text string allowing extension
+    * to arbitrary actions not otherwise handled by RIDDL's syntax.
     *
     * @param loc
     *   The location where the action occurs in the source
@@ -36,8 +36,8 @@ trait Actions {
     override def format: String = what.format
   }
 
-  /** An action that is intended to generate a runtime error in the generated application or otherwise indicate an error
-    * condition
+  /** An action that is intended to generate a runtime error in the generated
+    * application or otherwise indicate an error condition
     *
     * @param loc
     *   The location where the action occurs in the source
@@ -48,7 +48,8 @@ trait Actions {
     override def format: String = s"severe \"${message.format}\""
   }
 
-  /** An action whose behavior is to set the value of a state field to some expression
+  /** An action whose behavior is to set the value of a state field to some
+    * expression
     *
     * @param loc
     *   The location where the action occurs int he source
@@ -57,7 +58,8 @@ trait Actions {
     * @param value
     *   An expression for the value to set the field to
     */
-  case class AssignAction(loc: At, target: PathIdentifier, value: Expression) extends EntityAction {
+  case class AssignAction(loc: At, target: PathIdentifier, value: Expression)
+      extends EntityAction {
     override def format: String = {
       s"set ${target.format} to ${value.format}"
     }
@@ -72,16 +74,19 @@ trait Actions {
     * @param value
     *   An expression for the value to set the field to
     */
-  case class AppendAction(loc: At, value: Expression, target: PathIdentifier) extends EntityAction {
+  case class AppendAction(loc: At, value: Expression, target: PathIdentifier)
+      extends EntityAction {
     override def format: String = {
       s"append ${value.format} to ${target.format}"
     }
   }
 
-  /** A helper class for publishing messages that represents the construction of the message to be sent.
+  /** A helper class for publishing messages that represents the construction of
+    * the message to be sent.
     *
     * @param msg
-    *   A message reference that specifies the specific type of message to construct
+    *   A message reference that specifies the specific type of message to
+    *   construct
     * @param args
     *   An argument list that should correspond to teh fields of the message
     */
@@ -162,8 +167,9 @@ trait Actions {
     override def format: String = s"morph ${entity.format} to ${state.format}"
   }
 
-  /** An action that changes the behavior of an entity by making it use a new handler for its messages; named for the
-    * "become" operation in Akka that does the same for an user.
+  /** An action that changes the behavior of an entity by making it use a new
+    * handler for its messages; named for the "become" operation in Akka that
+    * does the same for an user.
     *
     * @param loc
     *   The location in the source of the become action
@@ -172,15 +178,18 @@ trait Actions {
     * @param handler
     *   The reference to the new handler for the entity
     */
-  case class BecomeAction(loc: At, entity: EntityRef, handler: HandlerRef) extends EntityAction {
+  case class BecomeAction(loc: At, entity: EntityRef, handler: HandlerRef)
+      extends EntityAction {
     override def format: String =
       s"become ${entity.format} to ${handler.format}"
   }
 
-  /** An action that tells a message to an entity. This is very analogous to the tell operator in Akka. Unlike using an
-    * Portlet, this implies a direct relationship between the telling entity and the told entity. This action is
-    * considered useful in "high cohesion" scenarios. Use [[SendAction]] to reduce the coupling between entities because
-    * the relationship is managed by a [[Context]]'s [[Connector]] instead.
+  /** An action that tells a message to an entity. This is very analogous to the
+    * tell operator in Akka. Unlike using an Portlet, this implies a direct
+    * relationship between the telling entity and the told entity. This action
+    * is considered useful in "high cohesion" scenarios. Use [[SendAction]] to
+    * reduce the coupling between entities because the relationship is managed
+    * by a [[Context]]'s [[Connector]] instead.
     *
     * @param loc
     *   The location of the tell action

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Actions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Actions.scala
@@ -6,10 +6,11 @@
 
 package com.reactific.riddl.language.ast
 
-/** This trait defines all the Actions that can be invoked from an Example and
-  * classified by the kind of definition to which they are applicable
+/** This trait defines all the Actions that can be invoked from an Example and classified by the kind of definition to
+  * which they are applicable
   */
-trait Actions extends Definitions {
+trait Actions {
+  this: Definitions with Expressions with Types with Options with AbstractDefinitions =>
 
   /** Base traits of Actions applicable to various processors */
   sealed trait ApplicationAction extends Action
@@ -20,8 +21,8 @@ trait Actions extends Definitions {
   sealed trait SagaAction extends Action
   sealed trait AnyAction extends Action
 
-  /** An action whose behavior is specified as a text string allowing extension
-    * to arbitrary actions not otherwise handled by RIDDL's syntax.
+  /** An action whose behavior is specified as a text string allowing extension to arbitrary actions not otherwise
+    * handled by RIDDL's syntax.
     *
     * @param loc
     *   The location where the action occurs in the source
@@ -35,8 +36,8 @@ trait Actions extends Definitions {
     override def format: String = what.format
   }
 
-  /** An action that is intended to generate a runtime error in the generated
-    * application or otherwise indicate an error condition
+  /** An action that is intended to generate a runtime error in the generated application or otherwise indicate an error
+    * condition
     *
     * @param loc
     *   The location where the action occurs in the source
@@ -47,8 +48,7 @@ trait Actions extends Definitions {
     override def format: String = s"severe \"${message.format}\""
   }
 
-  /** An action whose behavior is to set the value of a state field to some
-    * expression
+  /** An action whose behavior is to set the value of a state field to some expression
     *
     * @param loc
     *   The location where the action occurs int he source
@@ -57,8 +57,7 @@ trait Actions extends Definitions {
     * @param value
     *   An expression for the value to set the field to
     */
-  case class AssignAction(loc: At, target: PathIdentifier, value: Expression)
-      extends EntityAction {
+  case class AssignAction(loc: At, target: PathIdentifier, value: Expression) extends EntityAction {
     override def format: String = {
       s"set ${target.format} to ${value.format}"
     }
@@ -73,19 +72,16 @@ trait Actions extends Definitions {
     * @param value
     *   An expression for the value to set the field to
     */
-  case class AppendAction(loc: At, value: Expression, target: PathIdentifier)
-      extends EntityAction {
+  case class AppendAction(loc: At, value: Expression, target: PathIdentifier) extends EntityAction {
     override def format: String = {
       s"append ${value.format} to ${target.format}"
     }
   }
 
-  /** A helper class for publishing messages that represents the construction of
-    * the message to be sent.
+  /** A helper class for publishing messages that represents the construction of the message to be sent.
     *
     * @param msg
-    *   A message reference that specifies the specific type of message to
-    *   construct
+    *   A message reference that specifies the specific type of message to construct
     * @param args
     *   An argument list that should correspond to teh fields of the message
     */
@@ -166,9 +162,8 @@ trait Actions extends Definitions {
     override def format: String = s"morph ${entity.format} to ${state.format}"
   }
 
-  /** An action that changes the behavior of an entity by making it use a new
-    * handler for its messages; named for the "become" operation in Akka that
-    * does the same for an user.
+  /** An action that changes the behavior of an entity by making it use a new handler for its messages; named for the
+    * "become" operation in Akka that does the same for an user.
     *
     * @param loc
     *   The location in the source of the become action
@@ -177,18 +172,15 @@ trait Actions extends Definitions {
     * @param handler
     *   The reference to the new handler for the entity
     */
-  case class BecomeAction(loc: At, entity: EntityRef, handler: HandlerRef)
-      extends EntityAction {
+  case class BecomeAction(loc: At, entity: EntityRef, handler: HandlerRef) extends EntityAction {
     override def format: String =
       s"become ${entity.format} to ${handler.format}"
   }
 
-  /** An action that tells a message to an entity. This is very analogous to the
-    * tell operator in Akka. Unlike using an Portlet, this implies a direct
-    * relationship between the telling entity and the told entity. This action
-    * is considered useful in "high cohesion" scenarios. Use [[SendAction]] to
-    * reduce the coupling between entities because the relationship is managed
-    * by a [[Context]]'s [[Connector]] instead.
+  /** An action that tells a message to an entity. This is very analogous to the tell operator in Akka. Unlike using an
+    * Portlet, this implies a direct relationship between the telling entity and the told entity. This action is
+    * considered useful in "high cohesion" scenarios. Use [[SendAction]] to reduce the coupling between entities because
+    * the relationship is managed by a [[Context]]'s [[Connector]] instead.
     *
     * @param loc
     *   The location of the tell action

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
@@ -10,7 +10,9 @@ import com.reactific.riddl.language.parsing.RiddlParserInput
 import com.reactific.riddl.language.parsing.Terminals.Keywords
 
 /** Unit Tests For Definitions */
-trait Definitions extends Expressions with Options {
+trait Definitions {
+
+  this: Expressions with Options with Types with AbstractDefinitions =>
 
   /** Base trait of any definition that is in the content of an adaptor
     */

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Expressions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Expressions.scala
@@ -11,7 +11,8 @@ import com.reactific.riddl.language.parsing.Terminals.*
 import scala.collection.immutable.ListMap
 
 /** A trait for inclusion into AST object in AST.scala */
-trait Expressions extends Types {
+trait Expressions {
+  this: Types with AbstractDefinitions =>
 
 //////////////////////////////////////////////////////////// VALUE EXPRESSIONS
 
@@ -37,19 +38,16 @@ trait Expressions extends Types {
     @inline def expressionType: TypeExpression = Strng(loc)
   }
 
-  /** Represents the use of an arithmetic operator or well-known function call.
-    * The operator can be simple like addition or subtraction or complicated
-    * like pow, sqrt, etc. There is no limit on the number of operands but
-    * defining them shouldn't be necessary as they are pre-determined by use of
-    * the name of the operator (e.g. pow takes two floating point numbers, sqrt
-    * takes one.
+  /** Represents the use of an arithmetic operator or well-known function call. The operator can be simple like addition
+    * or subtraction or complicated like pow, sqrt, etc. There is no limit on the number of operands but defining them
+    * shouldn't be necessary as they are pre-determined by use of the name of the operator (e.g. pow takes two floating
+    * point numbers, sqrt takes one.
     * @param loc
     *   The location of the operator
     * @param operator
     *   The name of the operator (+, -, sqrt, ...)
     * @param operands
-    *   A list of expressions that correspond to the required operands for the
-    *   operator
+    *   A list of expressions that correspond to the required operands for the operator
     */
 
   case class ArithmeticOperator(
@@ -62,9 +60,8 @@ trait Expressions extends Types {
       .mkString("(", ",", ")")
   }
 
-  /** Represents an opoerator that is merely a reference to some value,
-    * presumably an entity state value but could also be a projector or
-    * repository value.
+  /** Represents an opoerator that is merely a reference to some value, presumably an entity state value but could also
+    * be a projector or repository value.
     *
     * @param loc
     *   The location of this expression
@@ -76,8 +73,7 @@ trait Expressions extends Types {
     def expressionType: TypeExpression = Abstract(loc)
   }
 
-  /** Represents a expression that will be specified later and uses the ???
-    * syntax to represent that condition.
+  /** Represents a expression that will be specified later and uses the ??? syntax to represent that condition.
     *
     * @param loc
     *   The location of the undefined condition
@@ -89,13 +85,11 @@ trait Expressions extends Types {
     override def isEmpty: Boolean = true
   }
 
-  /** The arguments of a [[FunctionCallExpression]] and
-    * [[AggregateConstructionExpression]] is a mapping between an argument name
-    * and the expression that provides the value for that argument.
+  /** The arguments of a [[FunctionCallExpression]] and [[AggregateConstructionExpression]] is a mapping between an
+    * argument name and the expression that provides the value for that argument.
     *
     * @param args
-    *   A mapping of Identifier to Expression to provide the arguments for the
-    *   function call.
+    *   A mapping of Identifier to Expression to provide the arguments for the function call.
     */
   case class ArgList(
     args: ListMap[Identifier, Expression] = ListMap
@@ -109,12 +103,11 @@ trait Expressions extends Types {
     override def isEmpty: Boolean = args.isEmpty
   }
 
-  /** A helper class for creating aggregates and messages that represents the
-    * construction of the message or aggregate value from parameters
+  /** A helper class for creating aggregates and messages that represents the construction of the message or aggregate
+    * value from parameters
     *
     * @param msg
-    *   A message reference that specifies the specific type of message to
-    *   construct
+    *   A message reference that specifies the specific type of message to construct
     * @param args
     *   An argument list that should correspond to teh fields of the message
     */
@@ -130,24 +123,23 @@ trait Expressions extends Types {
     def expressionType: TypeExpression = Abstract(loc)
   }
 
-  /** A helper class for creating expressions that represent the creation of a
-    * new entity identifier for a specific kind of entity.
+  /** A helper class for creating expressions that represent the creation of a new entity identifier for a specific kind
+    * of entity.
     *
     * @param loc
     *   The location of the expression in the source
     * @param entityId
     *   The [[PathIdentifier]] of the entity type for with the Id is created
     */
-  case class NewEntityIdOperator(loc: At, entityId: PathIdentifier)
-      extends Expression {
+  case class NewEntityIdOperator(loc: At, entityId: PathIdentifier) extends Expression {
     override def format: String = {
       Keywords.new_ + " Id(" + entityId.format + ")"
     }
     def expressionType: TypeExpression = UniqueId(loc, entityId)
   }
 
-  /** A RIDDL Function call. The only callable thing here is a function
-    * identified by its path identifier with a matching set of arguments
+  /** A RIDDL Function call. The only callable thing here is a function identified by its path identifier with a
+    * matching set of arguments
     *
     * @param loc
     *   The location of the function call expression
@@ -181,8 +173,7 @@ trait Expressions extends Types {
     * @param expressions
     *   The expressions that are grouped
     */
-  case class GroupExpression(loc: At, expressions: Seq[Expression])
-      extends Expression {
+  case class GroupExpression(loc: At, expressions: Seq[Expression]) extends Expression {
     override def format: String = {
       s"(${expressions.map(_.format).mkString(", ")})"
     }
@@ -192,8 +183,8 @@ trait Expressions extends Types {
     }
   }
 
-  /** Ternary operator to accept a conditional and two expressions and choose
-    * one of the expressions as the resulting value based on the conditional.
+  /** Ternary operator to accept a conditional and two expressions and choose one of the expressions as the resulting
+    * value based on the conditional.
     *
     * @param loc
     *   The location of the ternary operator
@@ -235,8 +226,7 @@ trait Expressions extends Types {
     * @param d
     *   The decimal number to use as the value of the expression
     */
-  case class DecimalValue(loc: At, d: BigDecimal)
-      extends NumericExpression(loc) {
+  case class DecimalValue(loc: At, d: BigDecimal) extends NumericExpression(loc) {
     override def format: String = d.toString
     override def expressionType: TypeExpression =
       Decimal(loc, Long.MaxValue, Long.MaxValue)
@@ -273,40 +263,35 @@ trait Expressions extends Types {
     override def format: String = "false"
   }
 
-  /** Represents an arbitrary condition that is specified merely with a literal
-    * string. This can't be easily processed downstream but provides the author
-    * with the ability to include arbitrary ideas/concepts into an condition
+  /** Represents an arbitrary condition that is specified merely with a literal string. This can't be easily processed
+    * downstream but provides the author with the ability to include arbitrary ideas/concepts into an condition
     * expression. For example in a when condition:
     * {{{
     *   example foo { when "the timer has expired" }
     * }}}
-    * shows the use of an arbitrary condition for the "when" part of a Gherkin
-    * example.
+    * shows the use of an arbitrary condition for the "when" part of a Gherkin example.
     *
     * @param cond
     *   The arbitrary condition provided as a quoted string
     */
-  case class ArbitraryCondition(loc: At, cond: LiteralString)
-      extends Condition(loc) {
+  case class ArbitraryCondition(loc: At, cond: LiteralString) extends Condition(loc) {
     override def format: String = cond.format
   }
 
-  /** Represents a condition that is merely a reference to some Boolean value,
-    * presumably an entity state value or parameter.
+  /** Represents a condition that is merely a reference to some Boolean value, presumably an entity state value or
+    * parameter.
     *
     * @param loc
     *   The location of this condition
     * @param path
     *   The path to the value for this condition
     */
-  case class ValueCondition(loc: At, path: PathIdentifier)
-      extends Condition(loc) {
+  case class ValueCondition(loc: At, path: PathIdentifier) extends Condition(loc) {
     override def format: String = "@" + path.format
   }
 
-  /** A RIDDL Function call to the function identified by its path identifier
-    * with a matching set of arguments. This function must return a boolean
-    * since it is defined as a Condition.
+  /** A RIDDL Function call to the function identified by its path identifier with a matching set of arguments. This
+    * function must return a boolean since it is defined as a Condition.
     *
     * @param loc
     *   The location of the function call expression
@@ -398,8 +383,7 @@ trait Expressions extends Types {
     * @param conditions
     *   The conditions (minimum 2) that must all be true for "and" to be true
     */
-  case class AndCondition(loc: At, conditions: Seq[Condition])
-      extends MultiCondition(loc) {
+  case class AndCondition(loc: At, conditions: Seq[Condition]) extends MultiCondition(loc) {
     override def format: String = "and" + super.format
   }
 
@@ -408,11 +392,9 @@ trait Expressions extends Types {
     * @param loc
     *   Location of the `or` condition
     * @param conditions
-    *   The conditions (minimum 2), any one of which must be true for "Or" to be
-    *   true
+    *   The conditions (minimum 2), any one of which must be true for "Or" to be true
     */
-  case class OrCondition(loc: At, conditions: Seq[Condition])
-      extends MultiCondition(loc) {
+  case class OrCondition(loc: At, conditions: Seq[Condition]) extends MultiCondition(loc) {
     override def format: String = "or" + super.format
   }
 
@@ -420,23 +402,20 @@ trait Expressions extends Types {
     * @param loc
     *   Location of the `xor` condition
     * @param conditions
-    *   The conditions (minimum 2), only one of which may be true for "xor" to
-    *   be true.
+    *   The conditions (minimum 2), only one of which may be true for "xor" to be true.
     */
-  case class XorCondition(loc: At, conditions: Seq[Condition])
-      extends MultiCondition(loc) {
+  case class XorCondition(loc: At, conditions: Seq[Condition]) extends MultiCondition(loc) {
     override def format: String = "xor" + super.format
   }
 
-  /** An arbitrary expression provided by a LiteralString Arbitrary expressions
-    * conform to the type based on the context in which they are found. Another
-    * way to think of it is that arbitrary expressions are assignment compatible
-    * with any other type For example, in an arithmetic expression like this
+  /** An arbitrary expression provided by a LiteralString Arbitrary expressions conform to the type based on the context
+    * in which they are found. Another way to think of it is that arbitrary expressions are assignment compatible with
+    * any other type For example, in an arithmetic expression like this
     * {{{
     *   +(42,"number of widgets in a wack-a-mole")
     * }}}
-    * the arbitrary expression given by the string conforms to a numeric type
-    * since the context is the addition of 42 and the arbitrary expression
+    * the arbitrary expression given by the string conforms to a numeric type since the context is the addition of 42
+    * and the arbitrary expression
     */
   case class ArbitraryExpression(cond: LiteralString) extends Expression {
     override def loc: At = cond.loc

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Expressions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Expressions.scala
@@ -38,16 +38,19 @@ trait Expressions {
     @inline def expressionType: TypeExpression = Strng(loc)
   }
 
-  /** Represents the use of an arithmetic operator or well-known function call. The operator can be simple like addition
-    * or subtraction or complicated like pow, sqrt, etc. There is no limit on the number of operands but defining them
-    * shouldn't be necessary as they are pre-determined by use of the name of the operator (e.g. pow takes two floating
-    * point numbers, sqrt takes one.
+  /** Represents the use of an arithmetic operator or well-known function call.
+    * The operator can be simple like addition or subtraction or complicated
+    * like pow, sqrt, etc. There is no limit on the number of operands but
+    * defining them shouldn't be necessary as they are pre-determined by use of
+    * the name of the operator (e.g. pow takes two floating point numbers, sqrt
+    * takes one.
     * @param loc
     *   The location of the operator
     * @param operator
     *   The name of the operator (+, -, sqrt, ...)
     * @param operands
-    *   A list of expressions that correspond to the required operands for the operator
+    *   A list of expressions that correspond to the required operands for the
+    *   operator
     */
 
   case class ArithmeticOperator(
@@ -60,8 +63,9 @@ trait Expressions {
       .mkString("(", ",", ")")
   }
 
-  /** Represents an opoerator that is merely a reference to some value, presumably an entity state value but could also
-    * be a projector or repository value.
+  /** Represents an opoerator that is merely a reference to some value,
+    * presumably an entity state value but could also be a projector or
+    * repository value.
     *
     * @param loc
     *   The location of this expression
@@ -73,7 +77,8 @@ trait Expressions {
     def expressionType: TypeExpression = Abstract(loc)
   }
 
-  /** Represents a expression that will be specified later and uses the ??? syntax to represent that condition.
+  /** Represents a expression that will be specified later and uses the ???
+    * syntax to represent that condition.
     *
     * @param loc
     *   The location of the undefined condition
@@ -85,11 +90,13 @@ trait Expressions {
     override def isEmpty: Boolean = true
   }
 
-  /** The arguments of a [[FunctionCallExpression]] and [[AggregateConstructionExpression]] is a mapping between an
-    * argument name and the expression that provides the value for that argument.
+  /** The arguments of a [[FunctionCallExpression]] and
+    * [[AggregateConstructionExpression]] is a mapping between an argument name
+    * and the expression that provides the value for that argument.
     *
     * @param args
-    *   A mapping of Identifier to Expression to provide the arguments for the function call.
+    *   A mapping of Identifier to Expression to provide the arguments for the
+    *   function call.
     */
   case class ArgList(
     args: ListMap[Identifier, Expression] = ListMap
@@ -103,11 +110,12 @@ trait Expressions {
     override def isEmpty: Boolean = args.isEmpty
   }
 
-  /** A helper class for creating aggregates and messages that represents the construction of the message or aggregate
-    * value from parameters
+  /** A helper class for creating aggregates and messages that represents the
+    * construction of the message or aggregate value from parameters
     *
     * @param msg
-    *   A message reference that specifies the specific type of message to construct
+    *   A message reference that specifies the specific type of message to
+    *   construct
     * @param args
     *   An argument list that should correspond to teh fields of the message
     */
@@ -123,23 +131,24 @@ trait Expressions {
     def expressionType: TypeExpression = Abstract(loc)
   }
 
-  /** A helper class for creating expressions that represent the creation of a new entity identifier for a specific kind
-    * of entity.
+  /** A helper class for creating expressions that represent the creation of a
+    * new entity identifier for a specific kind of entity.
     *
     * @param loc
     *   The location of the expression in the source
     * @param entityId
     *   The [[PathIdentifier]] of the entity type for with the Id is created
     */
-  case class NewEntityIdOperator(loc: At, entityId: PathIdentifier) extends Expression {
+  case class NewEntityIdOperator(loc: At, entityId: PathIdentifier)
+      extends Expression {
     override def format: String = {
       Keywords.new_ + " Id(" + entityId.format + ")"
     }
     def expressionType: TypeExpression = UniqueId(loc, entityId)
   }
 
-  /** A RIDDL Function call. The only callable thing here is a function identified by its path identifier with a
-    * matching set of arguments
+  /** A RIDDL Function call. The only callable thing here is a function
+    * identified by its path identifier with a matching set of arguments
     *
     * @param loc
     *   The location of the function call expression
@@ -173,7 +182,8 @@ trait Expressions {
     * @param expressions
     *   The expressions that are grouped
     */
-  case class GroupExpression(loc: At, expressions: Seq[Expression]) extends Expression {
+  case class GroupExpression(loc: At, expressions: Seq[Expression])
+      extends Expression {
     override def format: String = {
       s"(${expressions.map(_.format).mkString(", ")})"
     }
@@ -183,8 +193,8 @@ trait Expressions {
     }
   }
 
-  /** Ternary operator to accept a conditional and two expressions and choose one of the expressions as the resulting
-    * value based on the conditional.
+  /** Ternary operator to accept a conditional and two expressions and choose
+    * one of the expressions as the resulting value based on the conditional.
     *
     * @param loc
     *   The location of the ternary operator
@@ -226,7 +236,8 @@ trait Expressions {
     * @param d
     *   The decimal number to use as the value of the expression
     */
-  case class DecimalValue(loc: At, d: BigDecimal) extends NumericExpression(loc) {
+  case class DecimalValue(loc: At, d: BigDecimal)
+      extends NumericExpression(loc) {
     override def format: String = d.toString
     override def expressionType: TypeExpression =
       Decimal(loc, Long.MaxValue, Long.MaxValue)
@@ -263,35 +274,40 @@ trait Expressions {
     override def format: String = "false"
   }
 
-  /** Represents an arbitrary condition that is specified merely with a literal string. This can't be easily processed
-    * downstream but provides the author with the ability to include arbitrary ideas/concepts into an condition
+  /** Represents an arbitrary condition that is specified merely with a literal
+    * string. This can't be easily processed downstream but provides the author
+    * with the ability to include arbitrary ideas/concepts into an condition
     * expression. For example in a when condition:
     * {{{
     *   example foo { when "the timer has expired" }
     * }}}
-    * shows the use of an arbitrary condition for the "when" part of a Gherkin example.
+    * shows the use of an arbitrary condition for the "when" part of a Gherkin
+    * example.
     *
     * @param cond
     *   The arbitrary condition provided as a quoted string
     */
-  case class ArbitraryCondition(loc: At, cond: LiteralString) extends Condition(loc) {
+  case class ArbitraryCondition(loc: At, cond: LiteralString)
+      extends Condition(loc) {
     override def format: String = cond.format
   }
 
-  /** Represents a condition that is merely a reference to some Boolean value, presumably an entity state value or
-    * parameter.
+  /** Represents a condition that is merely a reference to some Boolean value,
+    * presumably an entity state value or parameter.
     *
     * @param loc
     *   The location of this condition
     * @param path
     *   The path to the value for this condition
     */
-  case class ValueCondition(loc: At, path: PathIdentifier) extends Condition(loc) {
+  case class ValueCondition(loc: At, path: PathIdentifier)
+      extends Condition(loc) {
     override def format: String = "@" + path.format
   }
 
-  /** A RIDDL Function call to the function identified by its path identifier with a matching set of arguments. This
-    * function must return a boolean since it is defined as a Condition.
+  /** A RIDDL Function call to the function identified by its path identifier
+    * with a matching set of arguments. This function must return a boolean
+    * since it is defined as a Condition.
     *
     * @param loc
     *   The location of the function call expression
@@ -383,7 +399,8 @@ trait Expressions {
     * @param conditions
     *   The conditions (minimum 2) that must all be true for "and" to be true
     */
-  case class AndCondition(loc: At, conditions: Seq[Condition]) extends MultiCondition(loc) {
+  case class AndCondition(loc: At, conditions: Seq[Condition])
+      extends MultiCondition(loc) {
     override def format: String = "and" + super.format
   }
 
@@ -392,9 +409,11 @@ trait Expressions {
     * @param loc
     *   Location of the `or` condition
     * @param conditions
-    *   The conditions (minimum 2), any one of which must be true for "Or" to be true
+    *   The conditions (minimum 2), any one of which must be true for "Or" to be
+    *   true
     */
-  case class OrCondition(loc: At, conditions: Seq[Condition]) extends MultiCondition(loc) {
+  case class OrCondition(loc: At, conditions: Seq[Condition])
+      extends MultiCondition(loc) {
     override def format: String = "or" + super.format
   }
 
@@ -402,20 +421,23 @@ trait Expressions {
     * @param loc
     *   Location of the `xor` condition
     * @param conditions
-    *   The conditions (minimum 2), only one of which may be true for "xor" to be true.
+    *   The conditions (minimum 2), only one of which may be true for "xor" to
+    *   be true.
     */
-  case class XorCondition(loc: At, conditions: Seq[Condition]) extends MultiCondition(loc) {
+  case class XorCondition(loc: At, conditions: Seq[Condition])
+      extends MultiCondition(loc) {
     override def format: String = "xor" + super.format
   }
 
-  /** An arbitrary expression provided by a LiteralString Arbitrary expressions conform to the type based on the context
-    * in which they are found. Another way to think of it is that arbitrary expressions are assignment compatible with
-    * any other type For example, in an arithmetic expression like this
+  /** An arbitrary expression provided by a LiteralString Arbitrary expressions
+    * conform to the type based on the context in which they are found. Another
+    * way to think of it is that arbitrary expressions are assignment compatible
+    * with any other type For example, in an arithmetic expression like this
     * {{{
     *   +(42,"number of widgets in a wack-a-mole")
     * }}}
-    * the arbitrary expression given by the string conforms to a numeric type since the context is the addition of 42
-    * and the arbitrary expression
+    * the arbitrary expression given by the string conforms to a numeric type
+    * since the context is the addition of 42 and the arbitrary expression
     */
   case class ArbitraryExpression(cond: LiteralString) extends Expression {
     override def loc: At = cond.loc

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Options.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Options.scala
@@ -20,13 +20,12 @@ trait Options {
 
     def args: Seq[LiteralString] = Seq.empty[LiteralString]
 
-    override def format: String = name + args
-      .map(_.format)
+    override def format: String = name + args.map(_.format)
       .mkString("(", ", ", ")")
   }
 
-  /** Base trait that can be used in any definition that takes options and ensures the options are defined, can be
-    * queried, and formatted.
+  /** Base trait that can be used in any definition that takes options and
+    * ensures the options are defined, can be queried, and formatted.
     *
     * @tparam T
     *   The sealed base trait of the permitted options for this definition
@@ -38,8 +37,7 @@ trait Options {
       .exists(_.getClass == implicitly[ClassTag[OPT]].runtimeClass)
 
     def getOptionValue[OPT <: T: ClassTag]: Option[Seq[LiteralString]] = options
-      .find(_.getClass == implicitly[ClassTag[OPT]].runtimeClass)
-      .map(_.args)
+      .find(_.getClass == implicitly[ClassTag[OPT]].runtimeClass).map(_.args)
 
     override def format: String = {
       options.size match {
@@ -59,7 +57,10 @@ trait Options {
 
   sealed abstract class AdaptorOption(val name: String) extends OptionValue
 
-  case class AdaptorTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends AdaptorOption("technology")
+  case class AdaptorTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends AdaptorOption("technology")
 
   //////////////////////////////////////////////////////////////////// HANDLER
 
@@ -71,14 +72,18 @@ trait Options {
 
   sealed abstract class ProjectorOption(val name: String) extends OptionValue
 
-  case class ProjectorTechnologyOption(loc: At, override val args: Seq[LiteralString])
+  case class ProjectorTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
       extends ProjectorOption("technology")
 
   /////////////////////////////////////////////////////////////////// PROJECTION
 
   sealed abstract class RepositoryOption(val name: String) extends OptionValue
 
-  case class RepositoryTechnologyOption(loc: At, override val args: Seq[LiteralString])
+  case class RepositoryTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
       extends RepositoryOption("technology")
 
   //////////////////////////////////////////////////////////////////// ENTITY
@@ -92,62 +97,71 @@ trait Options {
     * @param name
     *   the name of the option
     */
-  sealed abstract class EntityOption(val name: String) extends EntityValue with OptionValue
+  sealed abstract class EntityOption(val name: String)
+      extends EntityValue with OptionValue
 
-  /** An [[EntityOption]] that indicates that this entity should store its state in an event sourced fashion.
+  /** An [[EntityOption]] that indicates that this entity should store its state
+    * in an event sourced fashion.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityEventSourced(loc: At) extends EntityOption("event sourced")
 
-  /** An [[EntityOption]] that indicates that this entity should store only the latest value without using event
-    * sourcing. In other words, the history of changes is not stored.
+  /** An [[EntityOption]] that indicates that this entity should store only the
+    * latest value without using event sourcing. In other words, the history of
+    * changes is not stored.
     *
     * @param loc
     *   The location of the option
     */
   case class EntityValueOption(loc: At) extends EntityOption("value")
 
-  /** An [[EntityOption]] that indicates that this entity should not persist its state and is only available in
-    * transient memory. All entity values will be lost when the service is stopped.
+  /** An [[EntityOption]] that indicates that this entity should not persist its
+    * state and is only available in transient memory. All entity values will be
+    * lost when the service is stopped.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityTransient(loc: At) extends EntityOption("transient")
 
-  /** An [[EntityOption]] that indicates that this entity is an aggregate root entity through which all commands and
-    * queries are sent on behalf of the aggregated entities.
+  /** An [[EntityOption]] that indicates that this entity is an aggregate root
+    * entity through which all commands and queries are sent on behalf of the
+    * aggregated entities.
     *
     * @param loc
     *   The location of the option
     */
   case class EntityIsAggregate(loc: At) extends EntityOption("aggregate")
 
-  /** An [[EntityOption]] that indicates that this entity favors consistency over availability in the CAP theorem.
+  /** An [[EntityOption]] that indicates that this entity favors consistency
+    * over availability in the CAP theorem.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityIsConsistent(loc: At) extends EntityOption("consistent")
 
-  /** A [[EntityOption]] that indicates that this entity favors availability over consistency in the CAP theorem.
+  /** A [[EntityOption]] that indicates that this entity favors availability
+    * over consistency in the CAP theorem.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityIsAvailable(loc: At) extends EntityOption("available")
 
-  /** An [[EntityOption]] that indicates that this entity is intended to implement a finite state machine.
+  /** An [[EntityOption]] that indicates that this entity is intended to
+    * implement a finite state machine.
     *
     * @param loc
     *   The location of the option.
     */
-  case class EntityIsFiniteStateMachine(loc: At) extends EntityOption("finite state machine")
+  case class EntityIsFiniteStateMachine(loc: At)
+      extends EntityOption("finite state machine")
 
-  /** An [[EntityOption]] that indicates that this entity should allow receipt of commands and queries via a message
-    * queue.
+  /** An [[EntityOption]] that indicates that this entity should allow receipt
+    * of commands and queries via a message queue.
     *
     * @param loc
     *   The location at which this option occurs.
@@ -156,18 +170,24 @@ trait Options {
 
   case class EntityIsDevice(loc: At) extends EntityOption("device")
 
-  case class EntityTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends EntityOption("technology")
+  case class EntityTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends EntityOption("technology")
 
-  /** An [[EntityOption]] that indicates the general kind of entity being defined. This option takes a value which
-    * provides the kind. Examples of useful kinds are "device", "user", "concept", "machine", and similar kinds of
-    * entities. This entity option may be used by downstream AST processors, especially code generators.
+  /** An [[EntityOption]] that indicates the general kind of entity being
+    * defined. This option takes a value which provides the kind. Examples of
+    * useful kinds are "device", "user", "concept", "machine", and similar
+    * kinds of entities. This entity option may be used by downstream AST
+    * processors, especially code generators.
     *
     * @param loc
     *   The location of the entity kind option
     * @param args
     *   The argument to the option
     */
-  case class EntityKind(loc: At, override val args: Seq[LiteralString]) extends EntityOption("kind")
+  case class EntityKind(loc: At, override val args: Seq[LiteralString])
+      extends EntityOption("kind")
 
   //////////////////////////////////////////////////////////////////// FUNCTION
 
@@ -190,48 +210,63 @@ trait Options {
     */
   sealed abstract class ContextOption(val name: String) extends OptionValue
 
-  case class ContextPackageOption(loc: At, override val args: Seq[LiteralString]) extends ContextOption("package")
+  case class ContextPackageOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends ContextOption("package")
 
-  /** A context's "wrapper" option. This option suggests the bounded context is to be used as a wrapper around an
-    * external system and is therefore at the boundary of the context map
+  /** A context's "wrapper" option. This option suggests the bounded context is
+    * to be used as a wrapper around an external system and is therefore at the
+    * boundary of the context map
     *
     * @param loc
     *   The location of the wrapper option
     */
   case class WrapperOption(loc: At) extends ContextOption("wrapper")
 
-  /** A context's "service" option. This option suggests the bounded context is intended to be a DDD service, similar to
-    * a wrapper but without any persistent state and more of a stateless service aspect to its nature
+  /** A context's "service" option. This option suggests the bounded context is
+    * intended to be a DDD service, similar to a wrapper but without any
+    * persistent state and more of a stateless service aspect to its nature
     *
     * @param loc
     *   The location at which the option occurs
     */
   case class ServiceOption(loc: At) extends ContextOption("service")
 
-  /** A context's "gateway" option that suggests the bounded context is intended to be an application gateway to the
-    * model. Gateway's provide authentication and authorization access to external systems, usually user applications.
+  /** A context's "gateway" option that suggests the bounded context is intended
+    * to be an application gateway to the model. Gateway's provide
+    * authentication and authorization access to external systems, usually user
+    * applications.
     *
     * @param loc
     *   The location of the gateway option
     */
   case class GatewayOption(loc: At) extends ContextOption("gateway")
 
-  case class ContextTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends ContextOption("technology")
+  case class ContextTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends ContextOption("technology")
 
   //////////////////////////////////////////////////////////////////// PROCESSOR
 
   sealed abstract class StreamletOption(val name: String) extends OptionValue
 
-  case class StreamletTechnologyOption(loc: At, override val args: Seq[LiteralString])
+  case class StreamletTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
       extends StreamletOption(Terminals.Options.technology)
 
   //////////////////////////////////////////////////////////////////// PIPE
 
   sealed abstract class ConnectorOption(val name: String) extends OptionValue
 
-  case class ConnectorPersistentOption(loc: At) extends ConnectorOption("package")
+  case class ConnectorPersistentOption(loc: At)
+    extends ConnectorOption("package")
 
-  case class ConnectorTechnologyOption(loc: At, override val args: Seq[LiteralString])
+  case class ConnectorTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
       extends ConnectorOption("technology")
 
   //////////////////////////////////////////////////////////////////// SAGA
@@ -240,7 +275,8 @@ trait Options {
     */
   sealed abstract class SagaOption(val name: String) extends OptionValue
 
-  /** A [[SagaOption]] that indicates sequential (serial) execution of the saga actions.
+  /** A [[SagaOption]] that indicates sequential (serial) execution of the saga
+    * actions.
     *
     * @param loc
     *   The location of the sequential option
@@ -254,13 +290,18 @@ trait Options {
     */
   case class ParallelOption(loc: At) extends SagaOption("parallel")
 
-  case class SagaTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends SagaOption("technology")
+  case class SagaTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends SagaOption("technology")
 
   ////////////////////////////////////////////////////////////////// APPLICATION
 
   sealed abstract class ApplicationOption(val name: String) extends OptionValue
 
-  case class ApplicationTechnologyOption(loc: At, override val args: Seq[LiteralString] = Seq.empty[LiteralString])
+  case class ApplicationTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString] = Seq.empty[LiteralString])
       extends ApplicationOption("technology")
 
   ////////////////////////////////////////////////////////////////// DOMAIN
@@ -269,23 +310,33 @@ trait Options {
     */
   sealed abstract class DomainOption(val name: String) extends OptionValue
 
-  /** A context's "wrapper" option. This option suggests the bounded context is to be used as a wrapper around an
-    * external system and is therefore at the boundary of the context map
+  /** A context's "wrapper" option. This option suggests the bounded context is
+    * to be used as a wrapper around an external system and is therefore at the
+    * boundary of the context map
     *
     * @param loc
     *   The location of the wrapper option
     */
-  case class DomainPackageOption(loc: At, override val args: Seq[LiteralString]) extends DomainOption("package")
+  case class DomainPackageOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends DomainOption("package")
 
   case class DomainExternalOption(loc: At) extends DomainOption("external")
 
-  case class DomainTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends DomainOption("technology")
+  case class DomainTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends DomainOption("technology")
 
   ////////////////////////////////////////////////////////////////// DOMAIN
 
   sealed abstract class EpicOption(val name: String) extends OptionValue
 
-  case class EpicTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends EpicOption("technology")
+  case class EpicTechnologyOption(
+    loc: At,
+    override val args: Seq[LiteralString])
+      extends EpicOption("technology")
 
   case class EpicSynchronousOption(loc: At) extends EpicOption("synch")
 

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Options.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Options.scala
@@ -10,7 +10,8 @@ import com.reactific.riddl.language.parsing.Terminals
 import scala.reflect.ClassTag
 
 /** Option definitions for Vitals */
-trait Options extends AbstractDefinitions {
+trait Options {
+  this: AbstractDefinitions =>
 
   /** Base trait for option values for any option of a definition.
     */
@@ -19,12 +20,13 @@ trait Options extends AbstractDefinitions {
 
     def args: Seq[LiteralString] = Seq.empty[LiteralString]
 
-    override def format: String = name + args.map(_.format)
+    override def format: String = name + args
+      .map(_.format)
       .mkString("(", ", ", ")")
   }
 
-  /** Base trait that can be used in any definition that takes options and
-    * ensures the options are defined, can be queried, and formatted.
+  /** Base trait that can be used in any definition that takes options and ensures the options are defined, can be
+    * queried, and formatted.
     *
     * @tparam T
     *   The sealed base trait of the permitted options for this definition
@@ -36,7 +38,8 @@ trait Options extends AbstractDefinitions {
       .exists(_.getClass == implicitly[ClassTag[OPT]].runtimeClass)
 
     def getOptionValue[OPT <: T: ClassTag]: Option[Seq[LiteralString]] = options
-      .find(_.getClass == implicitly[ClassTag[OPT]].runtimeClass).map(_.args)
+      .find(_.getClass == implicitly[ClassTag[OPT]].runtimeClass)
+      .map(_.args)
 
     override def format: String = {
       options.size match {
@@ -56,10 +59,7 @@ trait Options extends AbstractDefinitions {
 
   sealed abstract class AdaptorOption(val name: String) extends OptionValue
 
-  case class AdaptorTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends AdaptorOption("technology")
+  case class AdaptorTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends AdaptorOption("technology")
 
   //////////////////////////////////////////////////////////////////// HANDLER
 
@@ -71,18 +71,14 @@ trait Options extends AbstractDefinitions {
 
   sealed abstract class ProjectorOption(val name: String) extends OptionValue
 
-  case class ProjectorTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
+  case class ProjectorTechnologyOption(loc: At, override val args: Seq[LiteralString])
       extends ProjectorOption("technology")
 
   /////////////////////////////////////////////////////////////////// PROJECTION
 
   sealed abstract class RepositoryOption(val name: String) extends OptionValue
 
-  case class RepositoryTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
+  case class RepositoryTechnologyOption(loc: At, override val args: Seq[LiteralString])
       extends RepositoryOption("technology")
 
   //////////////////////////////////////////////////////////////////// ENTITY
@@ -96,71 +92,62 @@ trait Options extends AbstractDefinitions {
     * @param name
     *   the name of the option
     */
-  sealed abstract class EntityOption(val name: String)
-      extends EntityValue with OptionValue
+  sealed abstract class EntityOption(val name: String) extends EntityValue with OptionValue
 
-  /** An [[EntityOption]] that indicates that this entity should store its state
-    * in an event sourced fashion.
+  /** An [[EntityOption]] that indicates that this entity should store its state in an event sourced fashion.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityEventSourced(loc: At) extends EntityOption("event sourced")
 
-  /** An [[EntityOption]] that indicates that this entity should store only the
-    * latest value without using event sourcing. In other words, the history of
-    * changes is not stored.
+  /** An [[EntityOption]] that indicates that this entity should store only the latest value without using event
+    * sourcing. In other words, the history of changes is not stored.
     *
     * @param loc
     *   The location of the option
     */
   case class EntityValueOption(loc: At) extends EntityOption("value")
 
-  /** An [[EntityOption]] that indicates that this entity should not persist its
-    * state and is only available in transient memory. All entity values will be
-    * lost when the service is stopped.
+  /** An [[EntityOption]] that indicates that this entity should not persist its state and is only available in
+    * transient memory. All entity values will be lost when the service is stopped.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityTransient(loc: At) extends EntityOption("transient")
 
-  /** An [[EntityOption]] that indicates that this entity is an aggregate root
-    * entity through which all commands and queries are sent on behalf of the
-    * aggregated entities.
+  /** An [[EntityOption]] that indicates that this entity is an aggregate root entity through which all commands and
+    * queries are sent on behalf of the aggregated entities.
     *
     * @param loc
     *   The location of the option
     */
   case class EntityIsAggregate(loc: At) extends EntityOption("aggregate")
 
-  /** An [[EntityOption]] that indicates that this entity favors consistency
-    * over availability in the CAP theorem.
+  /** An [[EntityOption]] that indicates that this entity favors consistency over availability in the CAP theorem.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityIsConsistent(loc: At) extends EntityOption("consistent")
 
-  /** A [[EntityOption]] that indicates that this entity favors availability
-    * over consistency in the CAP theorem.
+  /** A [[EntityOption]] that indicates that this entity favors availability over consistency in the CAP theorem.
     *
     * @param loc
     *   The location of the option.
     */
   case class EntityIsAvailable(loc: At) extends EntityOption("available")
 
-  /** An [[EntityOption]] that indicates that this entity is intended to
-    * implement a finite state machine.
+  /** An [[EntityOption]] that indicates that this entity is intended to implement a finite state machine.
     *
     * @param loc
     *   The location of the option.
     */
-  case class EntityIsFiniteStateMachine(loc: At)
-      extends EntityOption("finite state machine")
+  case class EntityIsFiniteStateMachine(loc: At) extends EntityOption("finite state machine")
 
-  /** An [[EntityOption]] that indicates that this entity should allow receipt
-    * of commands and queries via a message queue.
+  /** An [[EntityOption]] that indicates that this entity should allow receipt of commands and queries via a message
+    * queue.
     *
     * @param loc
     *   The location at which this option occurs.
@@ -169,24 +156,18 @@ trait Options extends AbstractDefinitions {
 
   case class EntityIsDevice(loc: At) extends EntityOption("device")
 
-  case class EntityTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends EntityOption("technology")
+  case class EntityTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends EntityOption("technology")
 
-  /** An [[EntityOption]] that indicates the general kind of entity being
-    * defined. This option takes a value which provides the kind. Examples of
-    * useful kinds are "device", "user", "concept", "machine", and similar
-    * kinds of entities. This entity option may be used by downstream AST
-    * processors, especially code generators.
+  /** An [[EntityOption]] that indicates the general kind of entity being defined. This option takes a value which
+    * provides the kind. Examples of useful kinds are "device", "user", "concept", "machine", and similar kinds of
+    * entities. This entity option may be used by downstream AST processors, especially code generators.
     *
     * @param loc
     *   The location of the entity kind option
     * @param args
     *   The argument to the option
     */
-  case class EntityKind(loc: At, override val args: Seq[LiteralString])
-      extends EntityOption("kind")
+  case class EntityKind(loc: At, override val args: Seq[LiteralString]) extends EntityOption("kind")
 
   //////////////////////////////////////////////////////////////////// FUNCTION
 
@@ -209,63 +190,48 @@ trait Options extends AbstractDefinitions {
     */
   sealed abstract class ContextOption(val name: String) extends OptionValue
 
-  case class ContextPackageOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends ContextOption("package")
+  case class ContextPackageOption(loc: At, override val args: Seq[LiteralString]) extends ContextOption("package")
 
-  /** A context's "wrapper" option. This option suggests the bounded context is
-    * to be used as a wrapper around an external system and is therefore at the
-    * boundary of the context map
+  /** A context's "wrapper" option. This option suggests the bounded context is to be used as a wrapper around an
+    * external system and is therefore at the boundary of the context map
     *
     * @param loc
     *   The location of the wrapper option
     */
   case class WrapperOption(loc: At) extends ContextOption("wrapper")
 
-  /** A context's "service" option. This option suggests the bounded context is
-    * intended to be a DDD service, similar to a wrapper but without any
-    * persistent state and more of a stateless service aspect to its nature
+  /** A context's "service" option. This option suggests the bounded context is intended to be a DDD service, similar to
+    * a wrapper but without any persistent state and more of a stateless service aspect to its nature
     *
     * @param loc
     *   The location at which the option occurs
     */
   case class ServiceOption(loc: At) extends ContextOption("service")
 
-  /** A context's "gateway" option that suggests the bounded context is intended
-    * to be an application gateway to the model. Gateway's provide
-    * authentication and authorization access to external systems, usually user
-    * applications.
+  /** A context's "gateway" option that suggests the bounded context is intended to be an application gateway to the
+    * model. Gateway's provide authentication and authorization access to external systems, usually user applications.
     *
     * @param loc
     *   The location of the gateway option
     */
   case class GatewayOption(loc: At) extends ContextOption("gateway")
 
-  case class ContextTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends ContextOption("technology")
+  case class ContextTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends ContextOption("technology")
 
   //////////////////////////////////////////////////////////////////// PROCESSOR
 
   sealed abstract class StreamletOption(val name: String) extends OptionValue
 
-  case class StreamletTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
+  case class StreamletTechnologyOption(loc: At, override val args: Seq[LiteralString])
       extends StreamletOption(Terminals.Options.technology)
 
   //////////////////////////////////////////////////////////////////// PIPE
 
   sealed abstract class ConnectorOption(val name: String) extends OptionValue
 
-  case class ConnectorPersistentOption(loc: At)
-    extends ConnectorOption("package")
+  case class ConnectorPersistentOption(loc: At) extends ConnectorOption("package")
 
-  case class ConnectorTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
+  case class ConnectorTechnologyOption(loc: At, override val args: Seq[LiteralString])
       extends ConnectorOption("technology")
 
   //////////////////////////////////////////////////////////////////// SAGA
@@ -274,8 +240,7 @@ trait Options extends AbstractDefinitions {
     */
   sealed abstract class SagaOption(val name: String) extends OptionValue
 
-  /** A [[SagaOption]] that indicates sequential (serial) execution of the saga
-    * actions.
+  /** A [[SagaOption]] that indicates sequential (serial) execution of the saga actions.
     *
     * @param loc
     *   The location of the sequential option
@@ -289,18 +254,13 @@ trait Options extends AbstractDefinitions {
     */
   case class ParallelOption(loc: At) extends SagaOption("parallel")
 
-  case class SagaTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends SagaOption("technology")
+  case class SagaTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends SagaOption("technology")
 
   ////////////////////////////////////////////////////////////////// APPLICATION
 
   sealed abstract class ApplicationOption(val name: String) extends OptionValue
 
-  case class ApplicationTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString] = Seq.empty[LiteralString])
+  case class ApplicationTechnologyOption(loc: At, override val args: Seq[LiteralString] = Seq.empty[LiteralString])
       extends ApplicationOption("technology")
 
   ////////////////////////////////////////////////////////////////// DOMAIN
@@ -309,33 +269,23 @@ trait Options extends AbstractDefinitions {
     */
   sealed abstract class DomainOption(val name: String) extends OptionValue
 
-  /** A context's "wrapper" option. This option suggests the bounded context is
-    * to be used as a wrapper around an external system and is therefore at the
-    * boundary of the context map
+  /** A context's "wrapper" option. This option suggests the bounded context is to be used as a wrapper around an
+    * external system and is therefore at the boundary of the context map
     *
     * @param loc
     *   The location of the wrapper option
     */
-  case class DomainPackageOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends DomainOption("package")
+  case class DomainPackageOption(loc: At, override val args: Seq[LiteralString]) extends DomainOption("package")
 
   case class DomainExternalOption(loc: At) extends DomainOption("external")
 
-  case class DomainTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends DomainOption("technology")
+  case class DomainTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends DomainOption("technology")
 
   ////////////////////////////////////////////////////////////////// DOMAIN
 
   sealed abstract class EpicOption(val name: String) extends OptionValue
 
-  case class EpicTechnologyOption(
-    loc: At,
-    override val args: Seq[LiteralString])
-      extends EpicOption("technology")
+  case class EpicTechnologyOption(loc: At, override val args: Seq[LiteralString]) extends EpicOption("technology")
 
   case class EpicSynchronousOption(loc: At) extends EpicOption("synch")
 

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Types.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Types.scala
@@ -9,7 +9,8 @@ package com.reactific.riddl.language.ast
 import com.reactific.riddl.language.parsing.Terminals.*
 
 /** A portion of the AST that deals with Types and TypeExpressions */
-trait Types extends AbstractDefinitions {
+trait Types {
+  this: AbstractDefinitions =>
 
 ///////////////////////////////////////////////////////////// TYPES
 


### PR DESCRIPTION
The scalac bug appears to be an exponential complexity explosion caused by deep inheritance heirarchies. Using self types upsets it less. Generation takes ~200s locally, but at least completes.