### PR TITLE
Fix 403: no errors for misnamed fields in aggregate constructor expression

### DIFF
--- a/passes/src/main/scala/com/reactific/riddl/passes/resolve/ReferenceMap.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/resolve/ReferenceMap.scala
@@ -35,9 +35,18 @@ case class ReferenceMap(messages: Messages.Accumulator) {
     map.update(pathId -> parent, definition)
   }
 
-  def definitionOf[T <: Definition](pid: PathIdentifier, parent: Definition): Option[T] = {
+  def definitionOf[T <: Definition : ClassTag](pid: PathIdentifier, parent: Definition): Option[T] = {
     val key = pid.format -> parent
-    map.get(key).map(_.asInstanceOf[T])
+    val clazz = classTag[T].runtimeClass
+    map.get(key) match {
+      case Some(value) =>
+        if clazz == value.getClass then
+          Some(value.asInstanceOf[T])
+        else
+          None
+      case None =>
+        None
+    }
   }
 }
 

--- a/passes/src/main/scala/com/reactific/riddl/passes/validate/BasicValidation.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/validate/BasicValidation.scala
@@ -32,21 +32,21 @@ trait BasicValidation {
     symbols.lookup[T](id)
   }
 
-  def pathIdToDefinition(
-    pid: PathIdentifier,
-    parents: Seq[Definition]
-  ): Option[Definition] = {
-    resolution.refMap.definitionOf(pid, parents.head)
-  }
-
-  @inline def resolvePath[T <: Definition](
+  def pathIdToDefinition[T <: Definition : ClassTag](
     pid: PathIdentifier,
     parents: Seq[Definition]
   ): Option[T] = {
-    pathIdToDefinition(pid, parents).map(_.asInstanceOf[T])
+    resolution.refMap.definitionOf[T](pid, parents.head)
   }
 
-  def resolvePidRelativeTo[T <: Definition](
+  @inline def resolvePath[T <: Definition : ClassTag](
+    pid: PathIdentifier,
+    parents: Seq[Definition]
+  ): Option[T] = {
+    pathIdToDefinition[T](pid, parents)
+  }
+
+  def resolvePidRelativeTo[T <: Definition : ClassTag](
     pid: PathIdentifier,
     relativeTo: Definition
   ): Option[T] = {

--- a/passes/src/main/scala/com/reactific/riddl/passes/validate/ValidationPass.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/validate/ValidationPass.scala
@@ -402,7 +402,7 @@ case class ValidationPass (input: PassInput) extends Pass(input) with StreamingV
     parents.headOption match {
       case Some(c: Context) =>
         checkContainer(parents, a)
-        resolvePath(a.context.pathId, parents).map { (target: Context) =>
+        resolvePath[Context](a.context.pathId, parents).map { (target: Context) =>
           if target == c then {
             val message =
               s"${a.identify} may not specify a target context that is " +

--- a/testkit/src/test/input/issues/403.riddl
+++ b/testkit/src/test/input/issues/403.riddl
@@ -1,0 +1,22 @@
+domain Example is {
+    context ExampleContext is {
+	command DoFoo is {foo: Foo}
+		type Foo is {
+			bar: String
+		}
+		entity FooEntity is {
+		  record FooExampleState is {
+	            foo: Foo
+	          }
+	          state FooExample of FooExampleState is {
+	            handler HandleFoo is {
+	              on command DooFoo {
+		          example TwoErrors {
+		            then set FooExample.foo to !Foo(badField = @DooFoo.badField)
+		          }
+	           } 
+	        }
+	    }
+    }
+  }
+}

--- a/testkit/src/test/input/issues/403.riddl
+++ b/testkit/src/test/input/issues/403.riddl
@@ -10,11 +10,11 @@ domain Example is {
 	          }
 	          state FooExample of FooExampleState is {
 	            handler HandleFoo is {
-	              on command DooFoo {
+	              on command ExampleContext.DoFoo {
 		          example TwoErrors {
-		            then set FooExample.foo to !Foo(badField = @DooFoo.badField)
+		            then set FooEntity.FooExampleState.foo to !Foo(badField = @DooFoo.badField)
 		          }
-	           } 
+	           }
 	        }
 	    }
     }

--- a/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
@@ -40,15 +40,16 @@ class ReportedIssuesTest extends ValidatingTest {
     "375" in {
       checkOne("375.riddl") {
         case Left(messages) =>
-          messages.length must be(10)
+          messages.length must be(11)
           val errors = messages.justErrors
-          errors.length must be(5)
+          errors.length must be(6)
           val f = errors.map(_.format)
           f contains ("Path 'DooFoo' was not resolved,")
           f contains ("Path 'FooExamplexxx.garbage' was not resolved,")
           f contains ("Path 'FooExamplexxxx.garbage' was not resolved")
           f contains ("Path 'Examplexxxx.Foo' was not resolved,")
           f contains ("Setting a value requires assignment compatibility, but field:")
+          f contains ("Expecting field name bar but got argument name garbage")
           val usage = messages.justUsage
           usage.length must be(5)
           val u = usage.map(_.format)
@@ -68,11 +69,12 @@ class ReportedIssuesTest extends ValidatingTest {
     "403" in {
       checkOne("403.riddl") {
         case Left(messages) =>
-          info(messages.format)
+          println(messages.format)
           val errors = messages.justErrors
           val warnings = messages.justWarnings
-          warnings must be(0)
-          errors must be(4)
+          warnings.size must be(2)
+          println(errors.format)
+          errors.size must be(2)
         case Right(result) =>
           fail("The test should fail")
       }

--- a/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
@@ -55,14 +55,26 @@ class ReportedIssuesTest extends ValidatingTest {
           u contains("Entity 'FooEntity' is unused")
           u contains("Entity 'OtherEntity' is unused:")
           u contains("Command 'DoFoo' is unused")
-          u contains("Record 'OtherState' is unused:")
-          u contains("Models without any streaming data will exhibit minimal effect:")
+          u contains ("Record 'OtherState' is unused:")
+          u contains ("Models without any streaming data will exhibit minimal effect:")
           info(messages.format)
           succeed
         case Right(result) =>
           val messages = result.messages
           val errors = messages.filter(_.kind.isError)
           errors mustBe empty
+      }
+    }
+    "403" in {
+      checkOne("403.riddl") {
+        case Left(messages) =>
+          info(messages.format)
+          val errors = messages.justErrors
+          val warnings = messages.justWarnings
+          warnings must be(0)
+          errors must be(4)
+        case Right(result) =>
+          fail("The test should fail")
       }
     }
   }


### PR DESCRIPTION
This issue turned up in #375 too, which started to fail when the solution for #403 was implemented.  That resulted in fixing the test case for #375 as well. 