### PR TITLE
Don't allow empty definition bodies

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Definitions.scala
@@ -476,6 +476,7 @@ trait Definitions {
   ) extends Definition
       with StateDefinition
       with ProcessorDefinition
+      with ProjectorDefinition
       with FunctionDefinition
       with DomainDefinition {
     override def contents: Seq[TypeDefinition] = {

--- a/language/src/main/scala/com/reactific/riddl/language/ast/Statements.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/ast/Statements.scala
@@ -192,7 +192,7 @@ trait Statements {
   }
 
   case class StopStatement(
-    loc: At,
+    loc: At
   ) extends Statement {
     override def kind: String = "Stop Statement"
     def format: String = "scall ${func.format}"

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/AdaptorParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/AdaptorParser.scala
@@ -34,12 +34,14 @@ private[parsing] trait AdaptorParser {
 
   private def adaptorDefinitions[u: P]: P[Seq[AdaptorDefinition]] = {
     P(
-      undefined(Seq.empty[AdaptorDefinition]) |
       (handler(StatementsSet.AdaptorStatements) | function | inlet |
-        outlet | adaptorInclude | term | constant | errorOnInvalidClose(Keywords.adaptor)
-      ).rep(1)
-
+        outlet | adaptorInclude | term | constant
+      )./.rep(1)
     )
+  }
+
+  private def adaptorBody[u:P]: P[Seq[AdaptorDefinition]] = {
+    undefined(Seq.empty[AdaptorDefinition])./ | adaptorDefinitions./
   }
 
   private def adaptorDirection[u: P]: P[AdaptorDirection] = {
@@ -56,7 +58,7 @@ private[parsing] trait AdaptorParser {
     P(
       location ~ Keywords.adaptor ~/ identifier ~ authorRefs ~
         adaptorDirection ~ contextRef ~ is ~ open ~ adaptorOptions ~
-        adaptorDefinitions ~ close ~ briefly ~ description
+        adaptorBody ~ close ~ briefly ~ description
     ).map {
       case (
             loc,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ApplicationParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ApplicationParser.scala
@@ -53,8 +53,7 @@ private[parsing] trait ApplicationParser {
   private def applicationDefinition[u: P]: P[ApplicationDefinition] = {
     P(
       group | handler(StatementsSet.ApplicationStatements) | function |
-        inlet | outlet | term | typeDef |
-        constant | applicationInclude | errorOnInvalidClose(Keywords.application)
+        inlet | outlet | term | typeDef | constant | applicationInclude 
     )
   }
 
@@ -66,8 +65,12 @@ private[parsing] trait ApplicationParser {
     include[ApplicationDefinition, u](applicationDefinitions(_))
   }
 
-  private def emptyApplication[
-    u: P
+  private def emptyApplication[u: P
+  ]: P[(Seq[ApplicationOption], Seq[ApplicationDefinition])] = {
+    undefined((Seq.empty[ApplicationOption], Seq.empty[ApplicationDefinition]))
+  }
+  
+  private def applicationBody[u: P
   ]: P[(Seq[ApplicationOption], Seq[ApplicationDefinition])] = {
     undefined((Seq.empty[ApplicationOption], Seq.empty[ApplicationDefinition]))
   }

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/CommonParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/CommonParser.scala
@@ -43,7 +43,7 @@ private[parsing] trait CommonParser extends NoWhiteSpaceParsers {
   def include[K <: Definition, u: P](
     parser: P[?] => P[Seq[K]]
   ): P[Include[K]] = {
-    P(Keywords.include ~/ literalString).map { (str: LiteralString) =>
+    P(Keywords.include ~/ literalString)./.map { (str: LiteralString) =>
       doInclude[K](str)(parser)
     }
   }
@@ -219,20 +219,10 @@ private[parsing] trait CommonParser extends NoWhiteSpaceParsers {
   def httpUrl[u: P]: P[java.net.URL] = {
     P(
       "http" ~ "s".? ~ "://" ~ hostString ~ (":" ~ portNum).? ~ "/" ~ urlPath
-    ).!.map(new URL(_))
+    ).!.map(java.net.URI(_).toURL)
   }
 
   def term[u: P]: P[Term] = {
-    P(location ~ Keywords.term ~ identifier ~ is ~ briefly ~ description)
-      .map(tpl => (Term.apply _).tupled(tpl))
-  }
-
-  def errorOnInvalidClose[u: P](kind: String): P[Line] = {
-    P(
-      invalidCloseLine
-    ).map { line =>
-      error(line.loc, s"Unexpected syntax when a $kind definition was expected", "")
-      line
-    }
+    P(location ~ Keywords.term ~ identifier ~ is ~ briefly ~ description)./.map(tpl => (Term.apply _).tupled(tpl))
   }
 }

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/DomainParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/DomainParser.scala
@@ -34,18 +34,7 @@ private[parsing] trait DomainParser {
   }
 
   private def domainInclude[u: P]: P[Include[DomainDefinition]] = {
-    include[DomainDefinition, u](domainContent(_))
-  }
-
-  private def domainContent[u: P]: P[Seq[DomainDefinition]] = {
-    P(
-      undefined(Seq.empty[DomainDefinition]) |
-        (
-          author | typeDef | context | user | epic | saga | domain | term |
-            constant | application | importDef | domainInclude |
-            errorOnInvalidClose(Keywords.domain)
-        ).rep(0)
-    )
+    include[DomainDefinition, u](domainDefinitions(_))
   }
 
   private def user[u: P]: P[User] = {
@@ -57,17 +46,28 @@ private[parsing] trait DomainParser {
     }
   }
 
+  private def domainDefinitions[u: P]: P[Seq[DomainDefinition]] = {
+    P(
+      author | typeDef | context | user | epic | saga | domain | term |
+        constant | application | importDef | domainInclude
+    )./.rep(1)
+  }
+
+  private def domainBody[u: P]: P[Seq[DomainDefinition]] = {
+    undefined(Seq.empty[DomainDefinition]) | domainDefinitions
+  }
+
   def domain[u: P]: P[Domain] = {
     P(
       location ~ Keywords.domain ~/ identifier ~ authorRefs ~ is ~ open ~/
-        domainOptions ~ domainContent ~ close ~/
+        domainOptions ~ domainBody ~ close ~/
         briefly ~ description
     ).map { case (loc, id, authorRefs, options, defs, briefly, description) =>
       val groups = defs.groupBy(_.getClass)
-      val authors = mapTo[AST.Author](groups.get(classOf[AST.Author]))
-      val subdomains = mapTo[AST.Domain](groups.get(classOf[AST.Domain]))
-      val types = mapTo[AST.Type](groups.get(classOf[AST.Type]))
-      val consts = mapTo[AST.Constant](groups.get(classOf[AST.Constant]))
+      val authors = mapTo[Author](groups.get(classOf[Author]))
+      val subdomains = mapTo[Domain](groups.get(classOf[Domain]))
+      val types = mapTo[Type](groups.get(classOf[Type]))
+      val consts = mapTo[Constant](groups.get(classOf[Constant]))
       val contexts = mapTo[Context](groups.get(classOf[Context]))
       val epics = mapTo[Epic](groups.get(classOf[Epic]))
       val sagas = mapTo[Saga](groups.get(classOf[Saga]))

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/EpicParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/EpicParser.scala
@@ -144,7 +144,6 @@ private[parsing] trait EpicParser {
   }
 
   type EpicBody = (
-    Seq[EpicOption],
     Option[UserStory],
     Seq[java.net.URL],
     Seq[EpicDefinition]
@@ -154,27 +153,27 @@ private[parsing] trait EpicParser {
     P(
       undefined(
         (
-          Seq.empty[EpicOption],
           Option.empty[UserStory],
           Seq.empty[java.net.URL],
           Seq.empty[EpicDefinition]
         )
-      ) |
-        (epicOptions ~ userStory.? ~ shownBy ~ epicDefinitions)
-    )./
+      )./ |
+        (userStory.? ~ shownBy ~ epicDefinitions)./
+    )
   }
 
   def epic[u: P]: P[Epic] = {
     P(
       location ~ Keywords.epic ~/ identifier ~ authorRefs ~ is ~ open ~
-        epicBody ~ close ~
+        epicOptions ~ epicBody ~ close ~
         briefly ~ description
     ).map {
       case (
             loc,
             id,
             authors,
-            (options, userStory, shownBy, definitions),
+            options,
+            (userStory, shownBy, definitions),
             briefly,
             description
           ) =>

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/HandlerParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/HandlerParser.scala
@@ -58,7 +58,7 @@ private[parsing] trait HandlerParser {
       Keywords.handler ~/ location ~ identifier ~ authorRefs ~ is ~ open ~
         handlerBody(set) ~
         close ~ briefly ~ description
-    ).map { case (loc, id, authors, clauses, briefly, desc) =>
+    )./.map { case (loc, id, authors, clauses, briefly, desc) =>
       Handler(
         loc,
         id,

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ProjectorParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ProjectorParser.scala
@@ -34,23 +34,14 @@ private[parsing] trait ProjectorParser {
 
   private def projectionDefinitions[u: P]: P[Seq[ProjectorDefinition]] = {
     P(
-      term | projectionInclude | handler(StatementsSet.ProjectorStatements) | function | inlet | outlet |
-        invariant | constant | typeDef | errorOnInvalidClose(Keywords.projector)
-    ).rep(0)
+      typeDef | term | projectionInclude | handler(StatementsSet.ProjectorStatements) | 
+        function | inlet | outlet | invariant | constant | typeDef 
+    )./.rep(1)
   }
 
-  private type ProjectionBody =
-    (Seq[ProjectorOption], Seq[Type], Seq[ProjectorDefinition])
-
-  private def projectionBody[u: P]: P[ProjectionBody] = {
+  private def projectionBody[u: P]: P[Seq[ProjectorDefinition]] = {
     P(
-      undefined(
-        (
-          Seq.empty[ProjectorOption],
-          Seq.empty[Type],
-          Seq.empty[ProjectorDefinition]
-        )
-      ) | (projectionOptions ~ typeDef.rep(0) ~ projectionDefinitions)
+      undefined(Seq.empty[ProjectorDefinition]) | projectionDefinitions
     )
   }
 
@@ -66,17 +57,19 @@ private[parsing] trait ProjectorParser {
   def projector[u: P]: P[Projector] = {
     P(
       location ~ Keywords.projector ~/ identifier ~ authorRefs ~ is ~ open ~
-        projectionBody ~ close ~ briefly ~ description
+        projectionOptions ~ projectionBody ~ close ~ briefly ~ description
     ).map {
       case (
             loc,
             id,
             authors,
-            (options, types, definitions),
+            options,
+            definitions,
             briefly,
             description
           ) =>
         val groups = definitions.groupBy(_.getClass)
+        val types = mapTo[Type](groups.get(classOf[Type]))
         val handlers = mapTo[Handler](groups.get(classOf[Handler]))
         val functions = mapTo[Function](groups.get(classOf[Function]))
         val constants = mapTo[Constant](groups.get(classOf[Constant]))

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/RepositoryParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/RepositoryParser.scala
@@ -35,9 +35,8 @@ private[parsing] trait RepositoryParser {
 
   private def repositoryDefinitions[u: P]: P[Seq[RepositoryDefinition]] = {
     P(
-      typeDef | handler(
-        StatementsSet.RepositoryStatements
-      ) | function | term | repositoryInclude | inlet | outlet | invalidCloseLine
+      typeDef | handler(StatementsSet.RepositoryStatements) |
+        function | term | repositoryInclude | inlet | outlet
     ).rep(0)
   }
 

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/SagaParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/SagaParser.scala
@@ -41,12 +41,10 @@ private[parsing] trait SagaParser {
   }
 
   private def sagaDefinitions[u: P]: P[Seq[SagaDefinition]] = {
-    P(sagaStep | inlet | outlet | function | term | sagaInclude |
-      errorOnInvalidClose(Keywords.saga)).rep(2)
+    P(sagaStep | inlet | outlet | function | term | sagaInclude)./.rep(2)
   }
 
   private type SagaBodyType = (
-    Seq[SagaOption],
     Option[Aggregation],
     Option[Aggregation],
     Seq[SagaDefinition]
@@ -54,22 +52,22 @@ private[parsing] trait SagaParser {
 
   private def sagaBody[u: P]: P[SagaBodyType] = {
     P(
-      undefined(
-        (Seq.empty[SagaOption], None, None, Seq.empty[SagaDefinition])
-      ) | (sagaOptions ~ input.? ~ output.? ~ sagaDefinitions)
+      undefined((None, None, Seq.empty[SagaDefinition])) |
+        (input.? ~ output.? ~ sagaDefinitions)
     )
   }
 
   def saga[u: P]: P[Saga] = {
     P(
       location ~ Keywords.saga ~ identifier ~ authorRefs ~ is ~ open ~
-        sagaBody ~ close ~ briefly ~ description
+        sagaOptions ~ sagaBody ~ close ~ briefly ~ description
     ).map {
       case (
             location,
             identifier,
             authors,
-            (options, input, output, definitions),
+            options,
+            (input, output, definitions),
             briefly,
             description
           ) =>

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/StreamingParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/StreamingParser.scala
@@ -76,11 +76,11 @@ private[parsing] trait StreamingParser {
     maxOutlets: Int
   ): P[Seq[StreamletDefinition]] = {
     P(
-      (inlet.rep(minInlets, " ", maxInlets) ~/
-        outlet.rep(minOutlets, " ", maxOutlets) ~/
+      (inlet./.rep(minInlets, " ", maxInlets) ~
+        outlet./.rep(minOutlets, " ", maxOutlets) ~
         (handler(StatementsSet.StreamStatements) | term |
-          streamletInclude(minInlets, maxInlets, minOutlets, maxOutlets))
-          .rep(0)).map { case (inlets, outlets, definitions) =>
+          streamletInclude(minInlets, maxInlets, minOutlets, maxOutlets)
+        )./.rep(0)).map { case (inlets, outlets, definitions) =>
         inlets ++ outlets ++ definitions
       }
     )
@@ -130,7 +130,7 @@ private[parsing] trait StreamingParser {
       location ~ keyword ~/ identifier ~ authorRefs ~ is ~ open ~
         streamletBody(minInlets, maxInlets, minOutlets, maxOutlets)  ~ close ~
         briefly ~ description
-    ).map { case (location, id, auths, (options, definitions), brief, desc) =>
+    )./.map { case (location, id, auths, (options, definitions), brief, desc) =>
       val groups = definitions.groupBy(_.getClass)
       val inlets = mapTo[Inlet](groups.get(classOf[Inlet]))
       val outlets = mapTo[Outlet](groups.get(classOf[Outlet]))

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/TopLevelParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/TopLevelParser.scala
@@ -17,7 +17,7 @@ import java.nio.file.Path
 
 /** Top level parsing rules */
 class TopLevelParser(rpi: RiddlParserInput)
-  extends DomainParser
+    extends DomainParser
     with AdaptorParser
     with ApplicationParser
     with ContextParser
@@ -37,7 +37,7 @@ class TopLevelParser(rpi: RiddlParserInput)
   push(rpi)
 
   def root[u: P]: P[Seq[RootDefinition]] = {
-    P(Start ~ (domain | author).rep(0) ~ End).map { contents =>
+    P(Start ~ (domain | author)./.rep(1) ~ End).map { contents =>
       pop
       contents
     }
@@ -50,9 +50,8 @@ object TopLevelParser {
     input: RiddlParserInput
   ): Either[Messages, RootContainer] = {
     val tlp = new TopLevelParser(input)
-    tlp.expectMultiple("test case", tlp.root(_)).map {
-      case (defs: Seq[RootDefinition], rpi) =>
-        RootContainer(defs, Seq(rpi))
+    tlp.expectMultiple("test case", tlp.root(_)).map { case (defs: Seq[RootDefinition], rpi) =>
+      RootContainer(defs, Seq(rpi))
     }
   }
 

--- a/language/src/test/input/domains/simpleDomain.riddl
+++ b/language/src/test/input/domains/simpleDomain.riddl
@@ -1,3 +1,3 @@
 domain foo is {
-
+  ???
 }

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/ParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/ParserTest.scala
@@ -29,7 +29,7 @@ class ParserTest extends ParsingTest {
         case Left(errors) =>
           errors must not be empty
           errors.head.message mustBe
-            "Expected one of (end-of-input | \"author\" | \"domain\")"
+            "Expected one of (\"author\" | \"domain\")"
         case Right(_) => fail("Invalid syntax should make an error")
       }
     }
@@ -43,7 +43,7 @@ class ParserTest extends ParsingTest {
       }
     }
     "allow an empty funky-name domain" in {
-      val input = RiddlParserInput("domain 'foo-fah|roo' is { }")
+      val input = RiddlParserInput("domain 'foo-fah|roo' is { ??? }")
       parseTopLevelDomain(input, _.contents.head) match {
         case Left(errors) =>
           val msg = errors.map(_.format).mkString
@@ -55,7 +55,7 @@ class ParserTest extends ParsingTest {
     }
     "allow nested domains" in {
       val input = RiddlParserInput("""domain foo is {
-                                     |domain bar is { }
+                                     |domain bar is { ??? }
                                      |}
                                      |""".stripMargin)
       parseTopLevelDomains(input) match {
@@ -73,8 +73,8 @@ class ParserTest extends ParsingTest {
       }
     }
     "allow multiple domains" in {
-      val input = RiddlParserInput("""domain foo is { }
-                                     |domain bar is { }
+      val input = RiddlParserInput("""domain foo is { ??? }
+                                     |domain bar is { ??? }
                                      |""".stripMargin)
       parseTopLevelDomains(input) match {
         case Left(errors) =>
@@ -120,7 +120,7 @@ class ParserTest extends ParsingTest {
       }
     }
     "allow context definitions in domains" in {
-      val input = RiddlParserInput("domain foo is { context bar is { } }")
+      val input = RiddlParserInput("domain foo is { context bar is { ??? } }")
       parseDomainDefinition[Context](input, _.contexts.head) match {
         case Left(errors) =>
           val msg = errors.map(_.format).mkString
@@ -132,7 +132,7 @@ class ParserTest extends ParsingTest {
     }
     "allow options on context definitions" in {
       val input = RiddlParserInput(
-        "context bar is { options (service, wrapper, gateway ) }"
+        "context bar is { options (service, wrapper, gateway ) ??? }"
       )
       parseContextDefinition[Context](input, identity) match {
         case Left(errors) =>
@@ -300,7 +300,7 @@ class ParserTest extends ParsingTest {
                     |function foo is {
                     |  requires {b:Boolean}
                     |  returns {i:Integer}
-                    |  body ???
+                    |  body { ??? }
                     |}
                     |""".stripMargin
 

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/TopLevelParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/TopLevelParserTest.scala
@@ -58,7 +58,7 @@ class TopLevelParserTest extends ParsingTestBase {
           List(
             StringParserInput(
               """domain foo is {
-              |
+              |  ???
               |}
               |""".stripMargin,
               "simpleDomain.riddl"
@@ -71,8 +71,27 @@ class TopLevelParserTest extends ParsingTestBase {
     "parse empty String" in {
       val expected =
         RootContainer(List(), List(StringParserInput("", "string")))
-      TopLevelParser.parse("") mustBe Right(expected)
+      TopLevelParser.parse("") match {
+        case Right(expected) =>
+          fail("Should have failed excpecting an author or domain")
+        case Left(messages) =>
+          messages.length mustBe(1)
+          val msg = messages.head
+          msg.message must include("Expected one of (\"author\" | \"domain\"")
+      }
+    }
+
+    "handle garbage" in {
+      val expected =
+        RootContainer(List(), List(StringParserInput("", "string")))
+      TopLevelParser.parse(" pweio afhj") match {
+        case Right(expected) =>
+          fail("Should have failed excpecting an author or domain")
+        case Left(messages) =>
+          messages.length mustBe(1)
+          val msg = messages.head
+          msg.message must include("Expected one of (\"author\" | \"domain\"")
+      }
     }
   }
-
 }

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/ContextValidationTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/ContextValidationTest.scala
@@ -17,7 +17,7 @@ class ContextValidationTest extends ValidatingTest {
   "Context" should {
     "allow options" in {
       val input =
-        """options (wrapper, service, gateway, package("foo"), technology("http"))"""
+        """options (wrapper, service, gateway, package("foo"), technology("http")) ??? """
       parseAndValidateContext(input) {
         case (context: Context, rpi, msgs: Messages) =>
           msgs.filter(_.kind.isError) mustBe empty
@@ -57,7 +57,7 @@ class ContextValidationTest extends ValidatingTest {
       val input = """function bar is {
                     |  requires { i: Integer }
                     |  returns { o: Integer }
-                    |  body ???
+                    |  body { ??? }
                     |}
                     |""".stripMargin
       parseAndValidateContext(input) {

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/EntityValidatorTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/EntityValidatorTest.scala
@@ -16,7 +16,7 @@ class EntityValidatorTest extends ValidatingTest {
     "handle a variety of options" in {
       val input = """entity WithOptions is {
                     | options(fsm, mq, aggregate, transient, available)
-                    |
+                    | ???
                     |}
                     |""".stripMargin
       parseAndValidateInContext[Entity](input, shouldFailOnErrors = false) {

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/RegressionTests.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/RegressionTests.scala
@@ -14,8 +14,8 @@ import com.reactific.riddl.language.parsing.RiddlParserInput
 class RegressionTests extends ValidatingTest {
   "Regressions" should {
     "allow descriptions as a single string" in {
-      val input = """domain foo is {
-                    |} explained as { "foo" }
+      val input = """domain foo is { ??? }
+                    |explained as { "foo" }
                     |""".stripMargin
       parseDefinition[Domain](RiddlParserInput(input)) match {
         case Left(errors) => fail(errors.format)
@@ -27,8 +27,8 @@ class RegressionTests extends ValidatingTest {
       }
     }
     "allow descriptions as a doc block" in {
-      val input = """domain foo is {
-                    |} explained as {
+      val input = """domain foo is { ??? }
+                    |explained as {
                     |  |ladeedah
                     |}
                     |""".stripMargin

--- a/prettify/src/test/scala/com/reactific/riddl/prettify/PrettifyTest.scala
+++ b/prettify/src/test/scala/com/reactific/riddl/prettify/PrettifyTest.scala
@@ -67,9 +67,6 @@ class PrettifyTest extends RiddlFilesTestBase {
 
     "check mappings" in { processADirectory("testkit/src/test/input/mappings") }
     "check ranges" in { processADirectory("testkit/src/test/input/ranges") }
-    "check empty.riddl" in {
-      processAFile("testkit/src/test/input/empty.riddl")
-    }
     "check everything.riddl" in {
       processAFile("testkit/src/test/input/everything.riddl")
     }

--- a/testkit/src/test/input/check/t0001/main.check
+++ b/testkit/src/test/input/check/t0001/main.check
@@ -2,8 +2,8 @@ Missing: testkit/src/test/input/check/t0001/main.riddl(1:1):
  Domain 'foo' in Root should have content:
  domain foo is {
  ^
-Missing: testkit/src/test/input/check/t0001/main.riddl(2:16):
- For Domain 'foo', description at main.riddl(2:16) is declared but empty
+Missing: testkit/src/test/input/check/t0001/main.riddl(3:16):
+ For Domain 'foo', description at main.riddl(3:16) is declared but empty
 Missing: testkit/src/test/input/check/t0001/main.riddl(1:1):
  Vital definitions should have an author reference:
  domain foo is {

--- a/testkit/src/test/input/check/t0001/main.riddl
+++ b/testkit/src/test/input/check/t0001/main.riddl
@@ -1,2 +1,3 @@
 domain foo is {
+  ???
 } described as { "" }

--- a/testkit/src/test/input/domains/simpleDomain.riddl
+++ b/testkit/src/test/input/domains/simpleDomain.riddl
@@ -1,3 +1,3 @@
 domain foo is {
-
+  ???
 }

--- a/testkit/src/test/input/petstore.riddl
+++ b/testkit/src/test/input/petstore.riddl
@@ -1,8 +1,11 @@
 domain PetStore is {
   context stock is {
+    ???
   }
   context register is {
+    ???
   }
   context payment is {
+    ???
   }
 }

--- a/testkit/src/test/scala/com/reactific/riddl/testkit/ExamplesTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/testkit/ExamplesTest.scala
@@ -31,7 +31,6 @@ class ExamplesTest extends ValidatingTest {
 
   "Examples" should {
     "compile Reactive BBQ" in { doOne("rbbq.riddl") }
-    "compile Empty" in { doOne("empty.riddl") }
     "compile Pet Store" in { doOne("petstore.riddl") }
     "compile Everything" in { doOne("everything.riddl") }
     "compile dokn" in { doOne("dokn.riddl") }

--- a/testkit/src/test/scala/com/reactific/riddl/testkit/IncludeAndImportTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/testkit/IncludeAndImportTest.scala
@@ -42,7 +42,8 @@ class IncludeAndImportTest extends ParsingTest {
     }
     "handle non existent URL" in {
       val emptyURL = new java.net.URL(
-        "https://raw.githubusercontent.com/reactific/riddl/main/testkit/src/test/input/domains/simpleDomain2.riddl")
+        "https://raw.githubusercontent.com/reactific/riddl/main/testkit/src/test/input/domains/simpleDomain2.riddl"
+      )
       parseDomainDefinition(
         RiddlParserInput(emptyURL),
         identity
@@ -55,8 +56,14 @@ class IncludeAndImportTest extends ParsingTest {
       }
     }
     "handle existing URL" in {
-      val fullURL = new java.net.URL(
-        "https://raw.githubusercontent.com/reactific/riddl/main/testkit/src/test/input/domains/simpleDomain.riddl")
+      import sys.process._
+      val branchName = "git branch --show-current".!!.trim
+      val fullURL = java.net
+        .URI(
+          s"https://raw.githubusercontent.com/reactific/riddl/$branchName/"
+            + "testkit/src/test/input/domains/simpleDomain.riddl"
+        )
+        .toURL
       parseDomainDefinition(
         RiddlParserInput(fullURL),
         identity
@@ -74,13 +81,13 @@ class IncludeAndImportTest extends ParsingTest {
       rc.domains.head.includes mustNot be(empty)
       rc.domains.head.includes.head.contents mustNot be(empty)
       val actual = rc.domains.head.includes.head.contents.head
-      val expected= Type(
+      val expected = Type(
         (1, 1, inc),
         Identifier((1, 6, inc), "foo"),
         Strng((1, 13, inc)),
         None
       )
-      actual == expected mustBe(true)
+      actual == expected mustBe (true)
     }
     "handle inclusions into contexts" in {
       val rc = checkFile("Context Includes", "contextIncludes.riddl")
@@ -96,7 +103,7 @@ class IncludeAndImportTest extends ParsingTest {
         Strng((1, 12, inc)),
         None
       )
-      actual mustBe( expected )
+      actual mustBe (expected)
     }
   }
 

--- a/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
@@ -73,7 +73,7 @@ class ReportedIssuesTest extends ValidatingTest {
           info(messages.format)
           messages.size must be(1)
           val message = messages.head.format
-          message must include("could not translate")
+          message must include("Expected")
 
         case Right(result) =>
           info(result.messages.format)


### PR DESCRIPTION
With this change:
* You can't make a definition body be "{ }" any more
* To get an empty definition, use "{ ??? }"
* Cuts have been added to generate better error messages
* Files with all syntax errors will not be silently ignored
This improves the error messages when junk occurs and eliminates the possibility of an included file being returned as an empty success. 
