### PR TITLE
Validate that messages to vital messages and their return messages

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ApplicationParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ApplicationParser.scala
@@ -17,7 +17,8 @@ private[parsing] trait ApplicationParser {
     with ReferenceParser
     with HandlerParser
     with StatementParser
-    with TypeParser =>
+    with TypeParser
+    with CommonParser =>
 
   private def applicationOptions[u: P]: P[Seq[ApplicationOption]] = {
     options[u, ApplicationOption](StringIn(Options.technology).!) { case (loc, Options.technology, args) =>
@@ -25,13 +26,7 @@ private[parsing] trait ApplicationParser {
     }
   }
 
-  private def groupAliases[u: P]: P[String] = {
-    P(
-      StringIn(Keywords.group, "page", "pane", "dialog", "popup", "frame", "column", "window", "section", "tab").!
-    )
-  }
-
-  private def groupDefinitions[u:P]: P[Seq[GroupDefinition]] = {
+  private def groupDefinitions[u: P]: P[Seq[GroupDefinition]] = {
     P {
       undefined(Seq.empty[GroupDefinition]) | (group | appOutput | appInput).rep(0)
     }
@@ -40,25 +35,11 @@ private[parsing] trait ApplicationParser {
   private def group[u: P]: P[Group] = {
     P(
       location ~ groupAliases ~ identifier ~/ is ~ open ~
-         groupDefinitions ~
-      close ~ briefly ~ description
+        groupDefinitions ~
+        close ~ briefly ~ description
     ).map { case (loc, alias, id, elements, brief, description) =>
       Group(loc, alias, id, elements, brief, description)
     }
-  }
-
-  private def outputAliases[u: P]: P[String] = {
-    P(
-      StringIn(
-        Keywords.output,
-        "document",
-        "list",
-        "table",
-        "graph",
-        "animation",
-        "picture"
-      ).!
-    )
   }
 
   private def presentationAliases[u: P]: P[Unit] = {
@@ -81,12 +62,6 @@ private[parsing] trait ApplicationParser {
     ).map { case (loc, alias, id, putOut, outputs, brief, description) =>
       Output(loc, alias, id, putOut, outputs, brief, description)
     }
-  }
-
-  private def inputAliases[u: P]: P[String] = {
-    P(
-      StringIn(Keywords.input, "form", "textblock", "button", "picklist").!
-    )
   }
 
   private def inputDefinitions[uP: P]: P[Seq[InputDefinition]] = {

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/CommonParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/CommonParser.scala
@@ -226,4 +226,31 @@ private[parsing] trait CommonParser extends NoWhiteSpaceParsers {
   def term[u: P]: P[Term] = {
     P(location ~ Keywords.term ~ identifier ~ is ~ briefly ~ description)./.map(tpl => (Term.apply _).tupled(tpl))
   }
+
+  def groupAliases[u: P]: P[String] = {
+    P(
+      StringIn(Keywords.group, "page", "pane", "dialog", "popup", "frame", "column", "window", "section", "tab").!
+    )
+  }
+
+  def inputAliases[u: P]: P[String] = {
+    P(
+      StringIn(Keywords.input, "form", "text", "button", "picklist", "select").!
+    )
+  }
+
+  def outputAliases[u: P]: P[String] = {
+    P(
+      StringIn(
+        Keywords.output,
+        "document",
+        "list",
+        "table",
+        "graph",
+        "animation",
+        "picture"
+      ).!
+    )
+  }
+
 }

--- a/language/src/main/scala/com/reactific/riddl/language/parsing/ReferenceParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/ReferenceParser.scala
@@ -156,18 +156,18 @@ private[parsing] trait ReferenceParser extends CommonParser {
   }
 
   def outputRef[u: P]: P[OutputRef] = {
-    P(location ~ Keywords.output ~ pathIdentifier)
-      .map(tpl => (OutputRef.apply _).tupled(tpl))
+    P(location ~ outputAliases ~ pathIdentifier)
+      .map { case (loc, _, pid) => OutputRef(loc, pid) }
   }
 
   def inputRef[u: P]: P[InputRef] = {
-    P(location ~ Keywords.input ~ pathIdentifier)
-      .map(tpl => (InputRef.apply _).tupled(tpl))
+    P(location ~ inputAliases ~ pathIdentifier)
+      .map { case (loc, _, pid) => InputRef(loc, pid) }
   }
 
-  def groupRef[u:P]: P[GroupRef] = {
-    P(location ~ Keywords.group ~ pathIdentifier)
-      .map(tpl => (GroupRef.apply _).tupled(tpl))
+  def groupRef[u: P]: P[GroupRef] = {
+    P(location ~ groupAliases ~ pathIdentifier)
+      .map { case (loc, _, pid) => GroupRef(loc, pid) }
   }
 
   def authorRefs[u: P]: P[Seq[AuthorRef]] = {
@@ -183,10 +183,9 @@ private[parsing] trait ReferenceParser extends CommonParser {
     )
   }
 
-  def arbitraryInteractionRef[u:P]: P[Reference[Definition]] = {
-    P( processorRef | sagaRef | inputRef | outputRef | groupRef )
+  def arbitraryInteractionRef[u: P]: P[Reference[Definition]] = {
+    P(processorRef | sagaRef | inputRef | outputRef | groupRef)
   }
-
 
   def anyInteractionRef[u: P]: P[Reference[Definition]] = {
     arbitraryInteractionRef | userRef

--- a/passes/src/main/scala/com/reactific/riddl/passes/validate/BasicValidation.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/validate/BasicValidation.scala
@@ -107,6 +107,14 @@ trait BasicValidation {
     }
   }
 
+  def checkTypeRef(
+    ref: TypeRef,
+    topDef: Definition,
+    parents: Seq[Definition]
+  ): Option[Type] = {
+    checkRef[Type](ref, topDef, parents)
+  }
+
   def checkMessageRef(
     ref: MessageRef,
     topDef: Definition,

--- a/testkit/src/test/input/issues/447.riddl
+++ b/testkit/src/test/input/issues/447.riddl
@@ -1,0 +1,21 @@
+domain example is {
+  context TenantControl {
+    command CreateTenant { name: String }
+    event TenantCreated { name: String, result: String }
+  }
+  record Create { name: String }
+  user Admin is "fickle"
+  application App is {
+    page NewTenantPage {
+      input NameEntry acquires record example.Create
+      button Create acquires record example.Create
+    }
+  }
+  epic check_for_wrong_types_to_and_from_vitals {
+    case UserCreatesANewCompany {
+      user Admin wants to "create a new tenant" so that "the tenant can do stuff"
+      step from user Admin "presses" button App.NewTenantPage.Create,
+      step from button App.NewTenantPage.Create "sends" to context TenantControl
+    }
+  }
+}

--- a/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
+++ b/testkit/src/test/scala/com/reactific/riddl/testkit/ReportedIssuesTest.scala
@@ -96,5 +96,13 @@ class ReportedIssuesTest extends ValidatingTest {
           succeed
       }
     }
+    "447" in {
+      checkOne("447.riddl") {
+        case Left(messages) =>
+          fail(messages.format)
+        case Right(result) =>
+          succeed
+      }
+    }
   }
 }


### PR DESCRIPTION
* groups/inputs/outputs remain the same but can have new alias names for syntactic sugar:
  * for groups :  "page", "pane", "dialog", "popup", "frame", "column", "window", "section", "tab", "panel", "modal"
  * for outputs:  "document", "list", "table"
  * for inputs: "form", "text", "button", "picklist"
* groups can already nest in groups but it should be possible to allow inputs to have inputs and outputs to have outputs 
* ability to send output of context calls to an input, e.g. sending validation data to a modal written like:
  `step take input from Form to context EntityContext.Entity`,  and outputs to Notification
* Allow inputs and outputs to handle any data type not just messages
* When input is sent to contexts or other backend definitions, they can only be commands and queries
* When output receives data from backend definitions, they can only be events or results