### PR TITLE
Fix statement validation and resolution

### DIFF
--- a/language/src/main/scala/com/reactific/riddl/language/parsing/EntityParser.scala
+++ b/language/src/main/scala/com/reactific/riddl/language/parsing/EntityParser.scala
@@ -52,7 +52,7 @@ private[parsing] trait EntityParser {
   }
 
   private def stateDefinitions[u: P]: P[Seq[StateDefinition]] = {
-    P(typeDef | handler(StatementsSet.EntityStatements) | invariant).rep(0)
+    P(handler(StatementsSet.EntityStatements) | invariant).rep(0)
   }
 
   private def stateBody[u: P]: P[Seq[StateDefinition]] = {
@@ -68,10 +68,9 @@ private[parsing] trait EntityParser {
       body match {
         case Some(defs) =>
           val groups = defs.groupBy(_.getClass)
-          val types = mapTo[Type](groups.get(classOf[Type]))
           val handlers = mapTo[Handler](groups.get(classOf[Handler]))
           val invariants = mapTo[Invariant](groups.get(classOf[Invariant]))
-          State(loc, id, typRef, types, handlers, invariants, brief, desc)
+          State(loc, id, typRef, handlers, invariants, brief, desc)
         case None =>
           State(loc, id, typRef, brief = brief, description = desc)
       }

--- a/language/src/test/scala/com/reactific/riddl/language/parsing/ParserTest.scala
+++ b/language/src/test/scala/com/reactific/riddl/language/parsing/ParserTest.scala
@@ -246,7 +246,6 @@ class ParserTest extends ParsingTest {
                 (3, 3, rpi),
                 Identifier((3, 9, rpi), "BurgerState"),
                 TypeRef((3, 24, rpi), PathIdentifier((3, 29, rpi), Seq("BurgerStruct"))),
-                List(),
                 Seq(Handler((4, 11, rpi), Identifier((4, 11, rpi), "BurgerHandler")))
               )
             ),

--- a/passes/src/main/scala/com/reactific/riddl/passes/Pass.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/Pass.scala
@@ -251,7 +251,7 @@ object Pass {
     }
   }
 
-  def apply(
+  def runStandardPasses(
     model: RootContainer,
     options: CommonOptions,
     shouldFailOnErrors: Boolean

--- a/passes/src/main/scala/com/reactific/riddl/passes/Riddl.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/Riddl.scala
@@ -24,7 +24,7 @@ object Riddl {
     options: CommonOptions = CommonOptions.empty,
     shouldFailOnError: Boolean = true,
   ): Either[Messages, PassesResult] = {
-    Pass(root, options, shouldFailOnError)
+    Pass.runStandardPasses(root, options, shouldFailOnError)
   }
 
   def parseAndValidate(

--- a/passes/src/main/scala/com/reactific/riddl/passes/symbols/SymbolsOutput.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/symbols/SymbolsOutput.scala
@@ -65,8 +65,15 @@ case class SymbolsOutput(
   }
 
   def contextOf(definition: Definition): Option[Context] = {
-    val tail = parentsOf(definition).dropWhile(_.getClass != classOf[Context])
-    tail.headOption.asInstanceOf[Option[Context]]
+    definition match {
+      case c: Context =>
+        Some(c)
+      case _ =>
+        val parents = parentsOf(definition)
+        val tail = parents.dropWhile(_.getClass != classOf[Context])
+        val result = tail.headOption.asInstanceOf[Option[Context]]
+        result
+    }
   }
 
   /** Get the full path of a definition

--- a/passes/src/main/scala/com/reactific/riddl/passes/symbols/SymbolsOutput.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/symbols/SymbolsOutput.scala
@@ -11,7 +11,6 @@ import com.reactific.riddl.language.Messages
 import com.reactific.riddl.passes.PassOutput
 import com.reactific.riddl.passes.symbols.Symbols.{Parentage, SymTab}
 
-import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.{ClassTag, classTag}
 

--- a/passes/src/main/scala/com/reactific/riddl/passes/validate/StreamingValidation.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/validate/StreamingValidation.scala
@@ -11,8 +11,6 @@ import com.reactific.riddl.language.{At, Messages}
 
 trait StreamingValidation extends TypeValidation {
 
-  // TODO: Validate Stream usage from statements
-
   def checkStreaming(root: RootContainer): Unit = {
     val start = root.domains.headOption.map(_.id.loc).getOrElse(At.empty)
     checkStreamingUsage(start)
@@ -101,6 +99,5 @@ trait StreamingValidation extends TypeValidation {
       val message = s"${inlet.identify} is not connected"
       messages.addWarning(inlet.loc, message)
     }
-
   }
 }

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/DomainValidatorTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/DomainValidatorTest.scala
@@ -27,7 +27,7 @@ class DomainValidatorTest extends ValidatingTest {
         Seq(rpi)
       )
 
-      Pass(root, CommonOptions(), true) match {
+      Pass.runStandardPasses(root, CommonOptions(), true) match {
         case Left(errors) => fail(errors.format)
         case Right(result) =>
           val theErrors: Messages = result.messages.justErrors

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/HandlerValidatorTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/HandlerValidatorTest.scala
@@ -130,7 +130,6 @@ class HandlerValidatorTest extends ValidatingTest {
       parseAndValidateDomain(input, CommonOptions.noMinorWarnings, shouldFailOnErrors = false) {
         case (_, _, msgs: Messages) =>
           msgs.justErrors mustBe empty
-
       }
     }
     "produce a warning for commands with no events sent" in {

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/StatementValidatorTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/StatementValidatorTest.scala
@@ -1,0 +1,46 @@
+package com.reactific.riddl.passes.validate
+import com.reactific.riddl.language.AST.RootContainer
+import com.reactific.riddl.language.Messages.{Messages, StyleWarning}
+import com.reactific.riddl.language.{CommonOptions, Messages}
+import com.reactific.riddl.language.parsing.RiddlParserInput
+
+class StatementValidatorTest extends ValidatingTest {
+
+  "Statement Validation" must {
+    "identify cross-context references" in {
+      val input =
+        """domain test {
+          |  context one {
+          |    command fee { ??? }
+          |    handler oneH is {
+          |      on command fee {
+          |        tell command two.pho to context test.two
+          |      }
+          |    }
+          |  }
+          |  context two {
+          |    command pho { ??? }
+          |    handler twoH is {
+          |      on command pho {
+          |        tell command one.fee to context test.one
+          |      }
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      parseAndValidate(input, "test case",CommonOptions(), shouldFailOnErrors = false) {
+        (root: RootContainer, _: RiddlParserInput, messages: Messages ) =>
+          info(messages.format)
+          root.isEmpty mustBe false
+          messages.hasErrors mustBe false
+          val warnings = messages.justWarnings
+          warnings.isEmpty mustBe false
+          messages.exists { (msg: Messages.Message) =>
+            msg.kind == StyleWarning &&
+            msg.message.contains("Cross-context references are ill-advised")
+          } must be(true)
+      }
+
+      }
+  }
+}

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/ValidatingTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/ValidatingTest.scala
@@ -29,7 +29,7 @@ abstract class ValidatingTest extends ParsingTest {
       case Left(errors) =>
         fail(errors.map(_.format).mkString("\n"))
       case Right(model) =>
-        Pass.apply(model, options, shouldFailOnErrors = false) match {
+        Pass.runStandardPasses(model, options, shouldFailOnErrors = false) match {
           case Left(messages) =>
             fail(messages.format)
           case Right(ao: PassesResult) =>
@@ -50,7 +50,7 @@ abstract class ValidatingTest extends ParsingTest {
       case Right((model: Domain, _)) =>
         val clazz = classTag[D].runtimeClass
         val root = RootContainer(Seq(model), Seq(rpi))
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(messages) =>
             fail(messages.format)
           case Right(ao) =>
@@ -76,7 +76,7 @@ abstract class ValidatingTest extends ParsingTest {
       case Left(errors) => fail(errors.format)
       case Right((model: Domain, _)) =>
         val root = RootContainer(Seq(model), Seq(rpi))
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) => fail(errors.format)
           case Right(ao) =>
             val reducedMessages = ao.messages.filterNot(_.loc.line == 1)
@@ -100,7 +100,7 @@ abstract class ValidatingTest extends ParsingTest {
         }
       case Right((model: Domain, rpi)) =>
         val root = RootContainer(Seq(model), Seq(rpi))
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(ao) =>
@@ -122,12 +122,15 @@ abstract class ValidatingTest extends ParsingTest {
         val msgs = errors.format
         fail(s"In $origin:\n$msgs")
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
-            fail(errors.format)
-          case Right(ao) =>
-            ao.root.inputs mustNot be(empty)
-            validation(root, root.inputs.head, ao.messages)
+            if shouldFailOnErrors then
+              fail(errors.format)
+            else
+              validation(root, root.inputs.head, errors)
+          case Right(pr: PassesResult) =>
+            pr.root.inputs mustNot be(empty)
+            validation(root, root.inputs.head, pr.messages)
         }
     }
   }
@@ -143,7 +146,7 @@ abstract class ValidatingTest extends ParsingTest {
       case Left(errors) =>
         fail(errors.format)
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(passesResult: PassesResult) =>
@@ -185,7 +188,7 @@ abstract class ValidatingTest extends ParsingTest {
         val msgs = errors.format
         fail(s"In $label:\n$msgs")
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(ao) =>
@@ -202,7 +205,7 @@ abstract class ValidatingTest extends ParsingTest {
     TopLevelParser.parse(file) match {
       case Left(errors) => fail(errors.format)
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(ao) =>

--- a/passes/src/test/scala/com/reactific/riddl/passes/validate/ValidationPassTest.scala
+++ b/passes/src/test/scala/com/reactific/riddl/passes/validate/ValidationPassTest.scala
@@ -35,7 +35,7 @@ class ValidationPassTest extends ValidatingTest {
           case Left(errors) => fail(errors.format)
           case Right(root) =>
             sharedRoot = root
-            Pass(root, CommonOptions(showMissingWarnings = false, showStyleWarnings = false), true) match {
+            Pass.runStandardPasses(root, CommonOptions(showMissingWarnings = false, showStyleWarnings = false), true) match {
               case Left(errors) =>
                 fail(errors.format)
               case Right(ao) =>

--- a/testkit/src/main/scala/com/reactific/riddl/testkit/ValidatingTest.scala
+++ b/testkit/src/main/scala/com/reactific/riddl/testkit/ValidatingTest.scala
@@ -34,7 +34,7 @@ abstract class ValidatingTest extends ParsingTest {
         val msgs = errors.format
         fail(s"In $origin:\n$msgs")
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(ao) =>
@@ -55,7 +55,7 @@ abstract class ValidatingTest extends ParsingTest {
       case Left(errors) =>
         fail(errors.format)
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(passesResult: PassesResult) =>
@@ -97,7 +97,7 @@ abstract class ValidatingTest extends ParsingTest {
         val msgs = errors.format
         fail(s"In $label:\n$msgs")
       case Right(root) =>
-        Pass(root, options, shouldFailOnErrors) match {
+        Pass.runStandardPasses(root, options, shouldFailOnErrors) match {
           case Left(errors) =>
             fail(errors.format)
           case Right(ao) =>

--- a/testkit/src/test/input/check/everything/everything.riddl
+++ b/testkit/src/test/input/check/everything/everything.riddl
@@ -90,7 +90,7 @@ domain Everything is {
       state otherThingState of type Everything.StateType is { ??? }
       handler fee is {
         on event ItHappened {
-          set field SomeOtherThing.otherThingState.nameField1 to "field ItHappened.when"
+          set field SomeOtherThing.otherThingState.someField1 to "field ItHappened.when"
         }
       }
     }

--- a/testkit/src/test/input/check/references/bad-pids.check
+++ b/testkit/src/test/input/check/references/bad-pids.check
@@ -73,3 +73,9 @@ Missing: testkit/src/test/input/check/references/bad-pids.riddl(13:11):
  Processing for commands should result in sending an event:
            on command DooFoo {
            ^
+Error: testkit/src/test/input/check/references/bad-pids.riddl(14:23):
+ Path 'FooExamplexxxx.garbage' was not resolved, in OnMessageClause 'On command DooFoo' because
+ the PathId is invalid since it's first element, FooExamplexxxx, does not exist in the model
+ and it should refer to a Field:
+             set field FooExamplexxxx.garbage to "record Foo"
+                       ^

--- a/testkit/src/test/input/issues/406.riddl
+++ b/testkit/src/test/input/issues/406.riddl
@@ -10,7 +10,7 @@ domain Example is {
 	    state FooExample of FooExampleState is {
 	      handler HandleFoo is {
 	        on command ToBar {
-		        morph entity FooEntity to state BarExampleState with record BarExampleState
+		        morph entity FooEntity to state BarExample with record BarExampleState
           }
         }
 	    }


### PR DESCRIPTION
* You can no longer define types in side state definitions
* Foreach statements are now validated to ensure the referenced value has a type with cardinality
* Fix a bug with references to processors
* Fix a bug with cross-context validation
* Fix a bug with statement references not being checked when they occur within an on-message clause
* Fix a wrong-parentage bug with resolving statement references
* Fix an "empty on .last" problem
* Fix a bug in checkThatPathIdMatchesFoundParentStack
* Remove unused code
* Allow "contextOf" to match the definition, if it is a Context!
* Implement a style warning for cross-context references
* Implement validation of statements in all On Clauses
* Rename Pass.apply to Pass.runStandardPasses for clarity
* Add a StatementValidatorTest case
* Fix a bug in ValidatingTest.parseAndValidate
* Fix bugs in test cases that now produce new error messages *