### PR TITLE
Handle symtab case for path resolution

### DIFF
--- a/passes/src/main/scala/com/reactific/riddl/passes/resolve/ResolutionPass.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/resolve/ResolutionPass.scala
@@ -10,7 +10,6 @@ import com.reactific.riddl.language.AST.{Entity, *}
 import com.reactific.riddl.language.{CommonOptions, Messages}
 import com.reactific.riddl.passes.{Pass, PassInfo, PassInput, PassOutput, PassesOutput}
 import com.reactific.riddl.passes.symbols.{SymbolsOutput, SymbolsPass}
-import com.reactific.riddl.utils.SeqHelpers.SeqHelpers
 
 import scala.collection.mutable
 import scala.reflect.{ClassTag, classTag}
@@ -276,6 +275,9 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
           case (d, _) :: Nil =>
             wrongType[T](pathId, parent, d)
             Seq.empty
+          case (d, pars) :: tail if tail.map(_._1).forall(x => x == d && isSameKind[T](x)) =>
+            resolved[T](pathId, parent, d)
+            d +: pars
           case list =>
             ambiguous[T](pathId, list)
             Seq.empty
@@ -351,7 +353,7 @@ case class ResolutionPass(input: PassInput, outputs: PassesOutput) extends Pass(
         findAnchorInParents(topName, parents) match
           case afip: AnchorFoundInParents => afip
           case _: AnchorNotFoundInParents =>
-            // Its not an ancestor so le'ts try the symbol table
+            // Its not an ancestor so let's try the symbol table
             findAnchorInSymTab(topName) match
               case afis: AnchorFoundInSymTab     => afis
               case anfis: AnchorNotFoundInSymTab => anfis

--- a/passes/src/main/scala/com/reactific/riddl/passes/symbols/SymbolsPass.scala
+++ b/passes/src/main/scala/com/reactific/riddl/passes/symbols/SymbolsPass.scala
@@ -57,6 +57,8 @@ case class SymbolsPass(input: PassInput, outputs: PassesOutput) extends Pass(inp
           val included: Seq[SymTabItem] = existing :+ (definition -> copy)
           symTab.update(name, included)
           parentage.update(definition, copy)
+        } else {
+          messages.addError(definition.loc, "Non implicit value with empty name should not happen")
         }
     }
   }

--- a/riddlc/src/test/scala/com/reactific/riddl/RunRiddlcOnArbitraryTest.scala
+++ b/riddlc/src/test/scala/com/reactific/riddl/RunRiddlcOnArbitraryTest.scala
@@ -24,7 +24,7 @@ class RunRiddlcOnArbitraryTest extends RunCommandSpecBase {
       val fullPath = Path.of(cwd, config)
       info(s"config path is: ${fullPath.toAbsolutePath.toString}")
       if Files.isReadable(fullPath) then {
-        val args = Seq("--show-times", "from", fullPath.toString, "validate")
+        val args = Seq("--show-times", "--verbose", "from", fullPath.toString, "validate")
         runWith(args)
       } else {
         info(s"Skipping unreadable $fullPath")
@@ -45,6 +45,11 @@ class RunRiddlcOnArbitraryTest extends RunCommandSpecBase {
     "validate OffTheTop" in {
       val cwd = "/Users/reid/Code/Improving/OffTheTop"
       val config = "design/src/main/riddl/OffTheTop.conf"
+      validateLocalProject(cwd, config)
+    }
+    "validate kalix template" in {
+      val cwd = "/Users/reid/Code/Improving/kalix-improving-template"
+      val config = "design/src/main/riddl/ksoapp.conf"
       validateLocalProject(cwd, config)
     }
     // FIXME: Fix Improving.app syntax and renable


### PR DESCRIPTION
If the multiple results from the symbol table only differ by the path to the same definition then
there is no ambiguity. This can happen because of
implicit definitions (includes).

Also, if a non-implicit unnamed entry in the symbol table occurs, make sure it generates an error

Also, add a new Arbitrary local test for the
kalix-improving-template project.