### PR TITLE
Fix Docker build credentials for sbt-ossuminc

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## Summary
- Adds GitHub Packages authentication to Docker build so `sbt-ossuminc:1.3.0` can be resolved
- Passes `GITHUB_TOKEN` as build-arg from the workflow into the Dockerfile
- Configures `~/.sbt/1.0/github.sbt` with credentials inside the Docker build

## Context
The Docker publish workflow has been failing because `sbt --batch update` couldn't resolve `sbt-ossuminc` from `maven.pkg.github.com` without credentials.

## Test plan
- [ ] Re-trigger docker-publish workflow after merge to verify image builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)